### PR TITLE
add sphinx_lfs_content extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,7 @@ release = __version__
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx_lfs_content",
     "sphinx_rtd_theme",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pyserial = "^3.1"
 [tool.poetry.group.docs.dependencies]
 sphinx = "~4.5.0"
 sphinx_rtd_theme = "~1.0.0"
+sphinx-lfs-content = "^1.1.1"
 
 [tool.poetry.group.dev.dependencies]
 coverage = {extras = ["toml"], version = "^5.1"}


### PR DESCRIPTION
readthedocs doesnt seem to natively support git LFS.