### PR TITLE
Robust decorator

### DIFF
--- a/belay/inspect.py
+++ b/belay/inspect.py
@@ -6,8 +6,10 @@ _pat_no_decorators = re.compile(
 )
 
 
-def getsource(f):
+def getsource(f) -> tuple[str, int, str]:
     """Get source code data without decorators.
+
+    Trims leading whitespace and removes decorators.
 
     Parameters
     ----------
@@ -23,8 +25,10 @@ def getsource(f):
     src_file: str
         Path to file containing source code.
     """
-    lines, src_lineno = inspect.getsourcelines(f)
     src_file = inspect.getsourcefile(f)
+    if src_file is None:
+        raise Exception(f"Unable to get source file for {f}.")
+    lines, src_lineno = inspect.getsourcelines(f)
 
     offset = 0
     for line in lines:
@@ -33,6 +37,11 @@ def getsource(f):
         offset += 1
 
     lines = lines[offset:]
+
+    # Trim leading whitespace
+    n_leading_whitespace = len(lines[0]) - len(lines[0].lstrip())
+    lines = [line[n_leading_whitespace:] for line in lines]
+
     src_code = "".join(lines)
     src_lineno += offset
 

--- a/belay/inspect.py
+++ b/belay/inspect.py
@@ -1,0 +1,39 @@
+import inspect
+import re
+
+_pat_no_decorators = re.compile(
+    r"^(\s*def\s)|(\s*async\s+def\s)|(.*(?<!\w)lambda(:|\s))"
+)
+
+
+def getsource(f):
+    """Get source code data without decorators.
+
+    Parameters
+    ----------
+    f: Callable
+        Function to get source code of.
+
+    Returns
+    -------
+    src_code: str
+        Source code.
+    src_lineno: int
+        Line number of code begin.
+    src_file: str
+        Path to file containing source code.
+    """
+    lines, src_lineno = inspect.getsourcelines(f)
+    src_file = inspect.getsourcefile(f)
+
+    offset = 0
+    for line in lines:
+        if _pat_no_decorators.match(line):
+            break
+        offset += 1
+
+    lines = lines[offset:]
+    src_code = "".join(lines)
+    src_lineno += offset
+
+    return src_code, src_lineno, src_file

--- a/belay/inspect.py
+++ b/belay/inspect.py
@@ -1,12 +1,13 @@
 import inspect
 import re
+from typing import Tuple
 
 _pat_no_decorators = re.compile(
     r"^(\s*def\s)|(\s*async\s+def\s)|(.*(?<!\w)lambda(:|\s))"
 )
 
 
-def getsource(f) -> tuple[str, int, str]:
+def getsource(f) -> Tuple[str, int, str]:
     """Get source code data without decorators.
 
     Trims leading whitespace and removes decorators.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+from distutils import dir_util
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def data_path(tmp_path, request):
+    """Temporary copy of folder with same name as test module.
+
+    Fixture responsible for searching a folder with the same name of test
+    module and, if available, copying all contents to a temporary directory so
+    tests can use them freely.
+    """
+    filename = Path(request.module.__file__)
+    test_dir = filename.parent / filename.stem
+    if test_dir.is_dir():
+        dir_util.copy_tree(str(test_dir), str(tmp_path))
+
+    return tmp_path

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,0 +1,70 @@
+from importlib.machinery import SourceFileLoader
+
+import pytest
+
+import belay.inspect
+
+
+@pytest.fixture
+def foo(data_path):
+    fn = data_path / "foo.py"
+    foo = SourceFileLoader("foo", str(fn)).load_module()
+    assert foo.__file__ == str(fn)
+    return foo
+
+
+def test_getsource_pattern_match():
+    pat = belay.inspect._pat_no_decorators
+    assert not pat.match("@device.task")
+    assert not pat.match("@device.task()")
+    assert not pat.match("@device.task(")
+    assert not pat.match("")
+    assert not pat.match("\n")
+
+    assert pat.match("def foo")
+    assert pat.match("def foo()")
+    assert pat.match("def foo(")
+    assert pat.match("def foo(\n\n")
+
+    assert pat.match("async def foo")
+    assert pat.match("async def foo()")
+    assert pat.match("async def foo(")
+    assert pat.match("async def foo(\n\n")
+
+
+def test_getsource_basic(foo):
+    code, lineno, file = belay.inspect.getsource(foo.foo)
+    assert code == "def foo(arg1, arg2):\n    return arg1 + arg2\n"
+    assert lineno == 15
+    assert file == foo.__file__
+
+
+def test_getsource_decorated_1(foo):
+    code, lineno, file = belay.inspect.getsource(foo.foo_decorated_1)
+    assert code == "def foo_decorated_1(arg1, arg2):\n    return arg1 + arg2\n"
+    assert lineno == 20
+    assert file == foo.__file__
+
+
+def test_getsource_decorated_2(foo):
+    code, lineno, file = belay.inspect.getsource(foo.foo_decorated_2)
+    assert code == "def foo_decorated_2(arg1, arg2):\n    return arg1 + arg2\n"
+    assert lineno == 25
+    assert file == foo.__file__
+
+
+def test_getsource_decorated_3(foo):
+    code, lineno, file = belay.inspect.getsource(foo.foo_decorated_3)
+    assert code == "def foo_decorated_3(arg1, arg2):\n    return arg1 + arg2\n"
+    assert lineno == 30
+    assert file == foo.__file__
+
+
+def test_getsource_decorated_4(foo):
+    code, lineno, file = belay.inspect.getsource(foo.foo_decorated_4)
+    assert (
+        code
+        == "def foo_decorated_4(\n    arg1,\n    arg2,\n):\n    return arg1 + arg2\n"
+    )
+    assert lineno == 35
+    assert file == foo.__file__

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -68,3 +68,11 @@ def test_getsource_decorated_4(foo):
     )
     assert lineno == 35
     assert file == foo.__file__
+
+
+def test_getsource_decorated_5(foo):
+    """Removes leading indent."""
+    code, lineno, file = belay.inspect.getsource(foo.foo_decorated_5)
+    assert code == "def foo_decorated_5(arg1, arg2):\n    return arg1 + arg2\n"
+    assert lineno == 45
+    assert file == foo.__file__

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -76,3 +76,11 @@ def test_getsource_decorated_5(foo):
     assert code == "def foo_decorated_5(arg1, arg2):\n    return arg1 + arg2\n"
     assert lineno == 45
     assert file == foo.__file__
+
+
+def test_getsource_decorated_6(foo):
+    """Double decorated."""
+    code, lineno, file = belay.inspect.getsource(foo.foo_decorated_6)
+    assert code == "def foo_decorated_6(arg1, arg2):\n    return arg1 + arg2\n"
+    assert lineno == 51
+    assert file == foo.__file__

--- a/tests/test_inspect/foo.py
+++ b/tests/test_inspect/foo.py
@@ -37,3 +37,10 @@ def foo_decorated_4(
     arg2,
 ):
     return arg1 + arg2
+
+
+if True:
+
+    @decorator
+    def foo_decorated_5(arg1, arg2):
+        return arg1 + arg2

--- a/tests/test_inspect/foo.py
+++ b/tests/test_inspect/foo.py
@@ -1,0 +1,39 @@
+from functools import wraps
+
+
+def decorator(f=None, **kwargs):
+    if f is None:
+        return decorator
+
+    @wraps(f)
+    def inner(*args, **kwargs):
+        return f(*args, **kwargs)
+
+    return inner
+
+
+def foo(arg1, arg2):
+    return arg1 + arg2
+
+
+@decorator
+def foo_decorated_1(arg1, arg2):
+    return arg1 + arg2
+
+
+@decorator()
+def foo_decorated_2(arg1, arg2):
+    return arg1 + arg2
+
+
+@decorator(some_kwarg="test")
+def foo_decorated_3(arg1, arg2):
+    return arg1 + arg2
+
+
+@decorator()
+def foo_decorated_4(
+    arg1,
+    arg2,
+):
+    return arg1 + arg2

--- a/tests/test_inspect/foo.py
+++ b/tests/test_inspect/foo.py
@@ -44,3 +44,9 @@ if True:
     @decorator
     def foo_decorated_5(arg1, arg2):
         return arg1 + arg2
+
+
+@decorator
+@decorator
+def foo_decorated_6(arg1, arg2):
+    return arg1 + arg2


### PR DESCRIPTION
* previously we just assumed that the `@device.task` and `@device.thread` decorator only took up one line. This PR fixes this assumption.
* this PR strips multiple decorators, but still won't properly handle multiple device registration. Currently each registration goes through properly thanks to `inspect.unwrap` and `functools.wraps`, but only the last device gets the executor assigned.