### PR TITLE
Multiple device support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,7 @@ max-line-length = 88
 # F401: Module imported but unused.
 # D100-D107: Missing docstrings
 # D200: One-line docstring should fit on one line with quotes.
-extend-ignore = E203,E402,E501,F401,D100,D101,D102,D103,D104,D105,D106,D107,D200
+extend-ignore = E203,E402,E501,F401,D100,D101,D102,D103,D104,D105,D106,D107,D200,D401
 docstring-convention = numpy
 # Ignore missing docstrings within unit testing functions.
 per-file-ignores = **/tests/:D100,D101,D102,D103,D104,D105,D106,D107

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,6 @@ repos:
     rev: v1.9.0
     hooks:
       - id: python-check-blanket-noqa
-      - id: python-check-blanket-type-ignore
       - id: python-check-mock-methods
       - id: python-no-log-warn
       - id: rst-backticks

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Belay
 
 Belay is a library that enables the rapid development of projects that interact with hardware via a micropython-compatible board.
 
-Belay works by automatically using the REPL interface of a micropython board from Python code running on PC.
+Belay works by interacting with the REPL interface of a micropython board from Python code running on PC.
 
 `Quick Video of Belay in 22 seconds.`_
 

--- a/belay/__init__.py
+++ b/belay/__init__.py
@@ -8,5 +8,5 @@ __all__ = [
     "PyboardException",
 ]
 from ._minify import minify
-from .device import Device, SpecialFilenameError
+from .device import Device, SpecialFilenameError, SpecialFunctionNameError
 from .pyboard import PyboardException

--- a/belay/device.py
+++ b/belay/device.py
@@ -91,7 +91,7 @@ def local_hash_file(fn):
     return binascii.hexlify(hasher.digest()).decode()
 
 
-class Executer(ABC):
+class _Executer(ABC):
     def __init__(self, device):
         # To avoid Executer.__setattr__ raising an error
         object.__setattr__(self, "_belay_device", device)
@@ -112,7 +112,7 @@ class Executer(ABC):
         raise NotImplementedError
 
 
-class TaskExecuter(Executer):
+class _TaskExecuter(_Executer):
     def __call__(
         self,
         f: Optional[Callable[..., JsonSerializeable]] = None,
@@ -120,7 +120,7 @@ class TaskExecuter(Executer):
         minify: bool = True,
         register: bool = True,
     ) -> Callable[..., JsonSerializeable]:
-        """Send code to device that executes when decorated function is called on-host.
+        """Decorator that send code to device that executes when decorated function is called on-host.
 
         Parameters
         ----------
@@ -180,7 +180,7 @@ class TaskExecuter(Executer):
         return multi_executer
 
 
-class ThreadExecuter(Executer):
+class _ThreadExecuter(_Executer):
     def __call__(
         self,
         f: Optional[Callable[..., None]] = None,
@@ -188,7 +188,7 @@ class ThreadExecuter(Executer):
         minify: bool = True,
         register: bool = True,
     ) -> Callable[..., None]:
-        """Send code to device that spawns a thread when executed.
+        """Decorator that send code to device that spawns a thread when executed.
 
         Parameters
         ----------
@@ -196,6 +196,7 @@ class ThreadExecuter(Executer):
             Function to decorate.
         minify: bool
             Minify ``cmd`` code prior to sending.
+            Defaults to ``True``.
         register: bool
             Assign an attribute to ``self`` with same name as ``f``.
             Defaults to ``True``.
@@ -260,8 +261,8 @@ class Device:
         self._board = Pyboard(*args, **kwargs)
         self._board.enter_raw_repl()
 
-        self.task = TaskExecuter(self)
-        self.thread = ThreadExecuter(self)
+        self.task = _TaskExecuter(self)
+        self.thread = _ThreadExecuter(self)
 
         self(_BELAY_STARTUP_CODE)
         if startup:

--- a/belay/device.py
+++ b/belay/device.py
@@ -148,10 +148,16 @@ class TaskExecuter(Executer):
         @wraps(f)
         def wrap(*args, **kwargs):
             cmd = f"{_BELAY_PREFIX + name}(*{args}, **{kwargs})"
-            return self._belay_device._traceback_execute(
-                src_file, src_lineno, name, cmd
-            )
 
+            res = self._belay_device._traceback_execute(src_file, src_lineno, name, cmd)
+
+            if hasattr(f, "__belay__"):
+                # Call next device's wrapper.
+                res = [res, f(*args, **kwargs)]
+
+            return res
+
+        wrap.__belay__ = self
         setattr(self, name, wrap)
 
         return wrap

--- a/belay/device.py
+++ b/belay/device.py
@@ -151,13 +151,19 @@ class TaskExecuter(Executer):
 
             res = self._belay_device._traceback_execute(src_file, src_lineno, name, cmd)
 
-            if hasattr(f, "__belay__"):
+            if hasattr(f, "_belay_level"):
                 # Call next device's wrapper.
-                res = [res, f(*args, **kwargs)]
+                if f._belay_level == 1:
+                    res = [f(*args, **kwargs), res]
+                else:
+                    res = [*f(*args, **kwargs), res]
 
             return res
 
-        wrap.__belay__ = self
+        wrap._belay_level = 1
+        if hasattr(f, "_belay_level"):
+            wrap._belay_level += f._belay_level
+
         setattr(self, name, wrap)
 
         return wrap

--- a/docs/source/Quick Start.rst
+++ b/docs/source/Quick Start.rst
@@ -48,6 +48,11 @@ Invoking ``bar = foo(5)`` on host sends a command to the device to execute the f
 The result, ``10``, is sent back to the host and results in ``bar == 10``.
 This is the preferable way to interact with hardware.
 
+If a task is registered to multiple Belay devices, it will execute sequentially on the devices in the order that they were decorated (bottom upwards).
+The return value would be a list of results in order.
+
+To explicitly call a task on just one device, it can be invoked ``device.task.foo()``.
+
 thread
 ^^^^^^
 
@@ -67,6 +72,10 @@ thread
 
 Not all MicroPython boards support threading, and those that do typically have a maximum of ``1`` thread.
 The decorated function has no return value.
+
+If a thread is registered to multiple Belay devices, it will execute sequentially on the devices in the order that they were decorated (bottom upwards).
+
+To explicitly call a thread on just one device, it can be invoked ``device.thread.led_loop()``.
 
 sync
 ^^^^

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,7 +1,29 @@
 API
 ===
 
+.. autoclass:: belay.Device
+   :members:
+
+   .. method:: task(f: Optional[Callable[..., None]] = None, /, minify: bool = True, register: bool = True)
+
+      Decorator that send code to device that executes when decorated function is called on-host.
+
+      :param Callable f: Function to decorate.
+      :param bool minify: Minify ``cmd`` code prior to sending. Defaults to ``True``.
+      :param bool register: Assign an attribute to ``self.task`` with same name as ``f``. Defaults to ``True``.
+
+   .. method:: thread(f: Optional[Callable[..., None]] = None, /, minify: bool = True, register: bool = True)
+
+      Decorator that send code to device that spawns a thread when executed.
+
+      :param Callable f: Function to decorate.
+      :param bool minify: Minify ``cmd`` code prior to sending. Defaults to ``True``.
+      :param bool register: Assign an attribute to ``self.thread`` with same name as ``f``. Defaults to ``True``.
+
+
+
 .. automodule:: belay
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: Device

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,6 +47,7 @@ templates_path = ["_templates"]
 exclude_patterns = []
 
 smartquotes = False
+add_module_names = False
 
 # Napoleon settings
 napoleon_google_docstring = True

--- a/examples/08_multiple_devices/README.rst
+++ b/examples/08_multiple_devices/README.rst
@@ -1,0 +1,6 @@
+Example 08: Multiple Devices
+============================
+
+Belay can interact with multiple micropython boards on different ports.
+Tasks and Threads can be decorated multiple times from different devices.
+When executed, devices are executed in the order that they were decorated (bottom upwards).

--- a/examples/08_multiple_devices/README.rst
+++ b/examples/08_multiple_devices/README.rst
@@ -3,4 +3,7 @@ Example 08: Multiple Devices
 
 Belay can interact with multiple micropython boards on different ports.
 Tasks and Threads can be decorated multiple times from different devices.
-When executed, devices are executed in the order that they were decorated (bottom upwards).
+When invoked, the resulting decorated function will execute on the devices in the order that they were decorated (bottom upwards).
+
+To execute a task on just one specific device, it can be accessed like ``device1.task.set_led``.
+Similarly, to execute a thread on just one specific device, call ``device1.thread.blink_loop``.

--- a/examples/08_multiple_devices/main.py
+++ b/examples/08_multiple_devices/main.py
@@ -1,0 +1,42 @@
+import argparse
+import time
+
+import belay
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--device1", default="/dev/ttyUSB0")
+parser.add_argument("--device2", default="/dev/ttyUSB1")
+args = parser.parse_args()
+
+device1 = belay.Device(args.device1)
+device2 = belay.Device(args.device2)
+
+
+# This sends the function's code over to the board.
+# Calling the local ``set_led`` function will
+# execute it on-device.
+@device1.task
+@device2.task
+def set_led(state):
+    # Configuration for a Pi Pico board.
+    Pin(25, Pin.OUT).value(state)
+
+
+print("Execute on all devices via decorated function.")
+for _ in range(5):
+    set_led(True)
+    time.sleep(0.5)
+    set_led(False)
+    time.sleep(0.5)
+
+print("Explicitly specify tasks per-device.")
+for _ in range(5):
+    device1.task.set_led(True)
+    device2.task.set_led(False)
+
+    time.sleep(0.5)
+
+    device1.task.set_led(False)
+    device2.task.set_led(True)
+
+    time.sleep(0.5)

--- a/examples/08_multiple_devices/main.py
+++ b/examples/08_multiple_devices/main.py
@@ -12,22 +12,23 @@ device1 = belay.Device(args.device1)
 device2 = belay.Device(args.device2)
 
 
-# This sends the function's code over to the board.
-# Calling the local ``set_led`` function will
-# execute it on-device.
-@device1.task
 @device2.task
+@device1.task
 def set_led(state):
     # Configuration for a Pi Pico board.
     Pin(25, Pin.OUT).value(state)
 
 
+# This will execute devices in order.
+# Decorators start from the bottom and work their way upward.
+# So device1 will execute, and upon completion, then device2 will execute.
 print("Execute on all devices via decorated function.")
 for _ in range(5):
     set_led(True)
     time.sleep(0.5)
     set_led(False)
     time.sleep(0.5)
+
 
 print("Explicitly specify tasks per-device.")
 for _ in range(5):
@@ -40,3 +41,39 @@ for _ in range(5):
     device2.task.set_led(True)
 
     time.sleep(0.5)
+
+
+print("Reading temperature from devices.")
+
+
+@device2.task
+@device1.task
+def read_temperature():
+    # ADC4 is attached to an internal temperature sensor
+    sensor_temp = ADC(4)
+    reading = sensor_temp.read_u16()
+    reading *= 3.3 / 65535  # Convert reading to a voltage.
+    temperature = 27 - (reading - 0.706) / 0.001721  # Convert voltage to Celsius
+    return temperature
+
+
+for _ in range(5):
+    device1_temp, device2_temp = read_temperature()
+    print(f"{device1_temp=:.1f}    {device2_temp=:.1f}")
+    time.sleep(0.5)
+
+
+print("Starting blinking thread on all devices.")
+
+
+@device2.thread
+@device1.thread
+def blink_thread():
+    while True:
+        set_led(True)
+        time.sleep(0.5)
+        set_led(False)
+        time.sleep(0.5)
+
+
+blink_thread()

--- a/examples/08_multiple_devices/main.py
+++ b/examples/08_multiple_devices/main.py
@@ -68,7 +68,7 @@ print("Starting blinking thread on all devices.")
 
 @device2.thread
 @device1.thread
-def blink_thread():
+def blink_loop():
     while True:
         set_led(True)
         time.sleep(0.5)
@@ -76,4 +76,4 @@ def blink_thread():
         time.sleep(0.5)
 
 
-blink_thread()
+blink_loop()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -50,6 +50,25 @@ def test_device_task(mocker, mock_device):
     )
 
 
+def test_device_task_chain(mocker, mock_pyboard):
+    mock_device1 = belay.Device()
+    mock_device1._traceback_execute = mocker.MagicMock(return_value=1)
+    mock_device2 = belay.Device()
+    mock_device2._traceback_execute = mocker.MagicMock(return_value=2)
+    mock_device3 = belay.Device()
+    mock_device3._traceback_execute = mocker.MagicMock(return_value=3)
+
+    @mock_device1.task
+    @mock_device2.task
+    @mock_device3.task
+    def foo(a, b):
+        c = a + b  # noqa: F841
+
+    res = foo("a", "b")
+
+    assert res == [3, 2, 1]
+
+
 def test_device_thread(mocker, mock_device):
     mock_device._traceback_execute = mocker.MagicMock()
 


### PR DESCRIPTION
This is basic multiple device support for `task` and `thread` decorators.

Currently, a shortcoming is that devices are invoked sequentially, when they could really be invoked at (more or less) the same time. However, this probably involves moving the serial interface to asyncio or similar, which for the current time might complicate the codebase unnecessarily. So, for now, devices will be invoked sequentially, and if a need comes to move to asyncio, we can figure that out later.