### PR TITLE
move all from strings in device.py to their own python submodule

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -20,3 +20,4 @@ exclude =
     venv
     .venv
     examples/
+    belay/snippets/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,12 @@ repos:
       - id: isort
         name: isort
         args: ["--profile=black"]
+        exclude: ^(belay/snippets/)
       - id: isort
         name: isort (cython)
         types: [cython]
         args: ["--profile=black"]
+        exclude: ^(belay/snippets/)
 
   - repo: https://github.com/psf/black
     rev: 22.3.0
@@ -33,6 +35,7 @@ repos:
           - "--target-version=py39"
           - "--target-version=py310"
         types: [python]
+        exclude: ^(belay/snippets/)
 
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.12.1
@@ -107,7 +110,7 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        exclude: ^(examples/|belay/pyboard.py)
+        exclude: ^(examples/|belay/snippets/|belay/pyboard.py)
         additional_dependencies:
           - flake8-2020
           - flake8-bugbear

--- a/belay/snippets/convenience_imports.py
+++ b/belay/snippets/convenience_imports.py
@@ -1,0 +1,4 @@
+import binascii, errno, hashlib, machine, os, time
+from machine import ADC, I2C, Pin, PWM, SPI, Timer
+from time import sleep
+from micropython import const

--- a/belay/snippets/startup.py
+++ b/belay/snippets/startup.py
@@ -1,0 +1,5 @@
+def __belay(f):
+    def belay_interface(*args, **kwargs):
+        print(repr(f(*args, **kwargs)))
+    globals()["_belay_" + f.__name__] = belay_interface
+    return f

--- a/belay/snippets/sync_begin.py
+++ b/belay/snippets/sync_begin.py
@@ -1,0 +1,26 @@
+# Creates and populates two set[str]: all_files, all_dirs
+import os, hashlib, binascii
+def __belay_hash_file(fn):
+    hasher = hashlib.sha256()
+    try:
+        with open(fn, "rb") as f:
+            while True:
+                data = f.read(4096)
+                if not data:
+                    break
+                hasher.update(data)
+    except OSError:
+        return "0" * 64
+    return str(binascii.hexlify(hasher.digest()))
+all_files, all_dirs = set(), []
+def enumerate_fs(path=""):
+    for elem in os.ilistdir(path):
+        full_name = path + "/" + elem[0]
+        if elem[1] & 0x4000:  # is_dir
+            all_dirs.append(full_name)
+            enumerate_fs(full_name)
+        else:
+            all_files.add(full_name)
+enumerate_fs()
+all_dirs.sort()
+del enumerate_fs

--- a/belay/snippets/sync_end.py
+++ b/belay/snippets/sync_end.py
@@ -1,0 +1,8 @@
+for file in all_files:
+    os.remove(file)
+for folder in reversed(all_dirs):
+    try:
+        os.rmdir(folder)
+    except OSError:
+        pass
+del all_files, all_dirs, __belay_hash_file

--- a/belay/snippets/try_mkdir.py
+++ b/belay/snippets/try_mkdir.py
@@ -1,0 +1,6 @@
+import os, errno
+try:
+    os.mkdir('%s')
+except OSError as e:
+    if e.errno != errno.EEXIST:
+        raise

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -175,7 +175,7 @@ def test_device_sync_partial_remote(mocker, mock_device, sync_path):
         if local_fn.stem.endswith("1"):
             return "0" * 64
         else:
-            return belay.device.local_hash_file(local_fn)
+            return belay.device._local_hash_file(local_fn)
 
     def side_effect(src_file, src_lineno, name, cmd):
         nonlocal __belay_hash_file


### PR DESCRIPTION
More organized and convenient for developing snippets that are sent to-device adhoc.