### PR TITLE
Fix sync exception, remove `SpecialFilenameError`, add sync `keep` argument.

### DIFF
--- a/belay/__init__.py
+++ b/belay/__init__.py
@@ -4,10 +4,9 @@ __version__ = "0.0.0"
 __all__ = [
     "minify",
     "Device",
-    "SpecialFilenameError",
     "SpecialFunctionNameError",
     "PyboardException",
 ]
 from ._minify import minify
-from .device import Device, SpecialFilenameError, SpecialFunctionNameError
+from .device import Device, SpecialFunctionNameError
 from .pyboard import PyboardException

--- a/belay/device.py
+++ b/belay/device.py
@@ -18,10 +18,6 @@ from .pyboard import Pyboard, PyboardException
 PythonLiteral = Union[None, bool, bytes, int, float, str, List, Dict, Set]
 
 
-class SpecialFilenameError(Exception):
-    """Reserved filename like ``boot.py`` or ``main.py`` that may impact Belay functionality."""
-
-
 class SpecialFunctionNameError(Exception):
     """Reserved function name that may impact Belay functionality.
 
@@ -316,11 +312,6 @@ class Device:
         local_files = sorted(folder.rglob("*"))
         for src in local_files:
             dst = f"/{src.relative_to(folder)}"
-
-            if dst in {"boot.py", "main.py"}:
-                raise SpecialFilenameError(
-                    f"Cannot upload {dst}, would interfere with REPL."
-                )
 
             with tempfile.TemporaryDirectory() as tmp_dir:
                 tmp_dir = Path(tmp_dir)  # Used if we need to perform a conversion

--- a/belay/device.py
+++ b/belay/device.py
@@ -301,12 +301,12 @@ class Device:
         folder: str, Path
             Directory of files to sync to the root of the board's filesystem.
         """
-        folder = Path(folder)
+        folder = Path(folder).resolve()
 
         if not folder.exists():
-            raise ValueError(f"{dir} does not exist")
+            raise ValueError(f'"{folder}" does not exist.')
         if not folder.is_dir():
-            raise ValueError(f"{dir} is not a directory.")
+            raise ValueError(f'"{folder}" is not a directory.')
 
         # Create a list of all files and dirs (on-device).
         # This is so we know what to clean up after done syncing.


### PR DESCRIPTION
- Fixed bad message for `ValueError` in `Device.sync`. Make the reported folder path absolute to aid in debugging.
- Removed `SpecialFilenameError`. `boot.py` and `main.py` dont interfere with Belay operation, and may actually be necessary for some projects.
- Added optional parameter `keep` to `Device.sync`. File(s) provided will NOT be deleted from the device's filesystem if not present in the sync directory. If those files exist in the sync directory, they will overwrite the contents on-device (as usual). Defaults to `["boot.py", "webrep_cfg.py"]`, since these files may contain device-specific configurations.