### PR TITLE
Connection Retry

### DIFF
--- a/belay/__init__.py
+++ b/belay/__init__.py
@@ -9,6 +9,6 @@ __all__ = [
     "PyboardException",
 ]
 from ._minify import minify
-from .device import Device, SpecialFunctionNameError
+from .device import ConnectionLost, Device, SpecialFunctionNameError
 from .exceptions import AuthenticationError
 from .pyboard import PyboardException

--- a/belay/__init__.py
+++ b/belay/__init__.py
@@ -16,7 +16,7 @@ from .exceptions import (
     AuthenticationError,
     ConnectionLost,
     FeatureUnavailableError,
-    ReconstructionError,
+    MaxHistoryLengthError,
     SpecialFunctionNameError,
 )
 from .pyboard import PyboardException

--- a/belay/device.py
+++ b/belay/device.py
@@ -19,7 +19,7 @@ from ._minify import minify as minify_code
 from .exceptions import (
     ConnectionLost,
     FeatureUnavailableError,
-    ReconstructionError,
+    MaxHistoryLengthError,
     SpecialFunctionNameError,
 )
 from .inspect import getsource
@@ -537,7 +537,7 @@ class Device:
 
     def reconnect(self, attempts=None):
         if len(self._cmd_history) == self.MAX_CMD_HISTORY_LEN:
-            raise ReconstructionError
+            raise MaxHistoryLengthError
 
         kwargs = self._board_kwargs.copy()
         kwargs["attempts"] = self.attempts if attempts is None else attempts

--- a/belay/device.py
+++ b/belay/device.py
@@ -313,7 +313,7 @@ class Device:
             Code to run on startup. Defaults to a few common imports.
         attempts: int
             If device disconnects, attempt to re-connect this many times (with 1 second between attempts).
-            WARNING: this may result in unexpectedly long blocking calls!
+            WARNING: this may result in unexpectedly long blocking calls when reconnecting!
         """
         self._board_kwargs = signature(Pyboard).bind(*args, **kwargs).arguments
         self.attempts = attempts
@@ -568,6 +568,9 @@ class Device:
             Name of the function.
         cmd: str
             Python command that executes a function on-device.
+        record: bool
+            Record the call for state-reconstruction if device is accidentally reset.
+            Defaults to ``True``.
         """
         src_file = str(src_file)
 

--- a/belay/device.py
+++ b/belay/device.py
@@ -290,7 +290,7 @@ class Device:
         startup: str
             Code to run on startup. Defaults to a few common imports.
         attempts: int
-            If device disconnects, attempt to re-connect this many times (with 2 seconds between tries).
+            If device disconnects, attempt to re-connect this many times (with 1 second between attempts).
             WARNING: this may result in unexpectedly long blocking calls!
         """
         self._board_kwargs = signature(Pyboard).bind(*args, **kwargs).arguments

--- a/belay/exceptions.py
+++ b/belay/exceptions.py
@@ -21,7 +21,7 @@ class SpecialFunctionNameError(BelayException):
     """
 
 
-class ReconstructionError(BelayException):
+class MaxHistoryLengthError(BelayException):
     """Too many commands were given."""
 
 

--- a/belay/exceptions.py
+++ b/belay/exceptions.py
@@ -1,12 +1,16 @@
-class AuthenticationError(Exception):
+class BelayException(Exception):
+    """Root Belay Exception class."""
+
+
+class AuthenticationError(BelayException):
     """Invalid password or similar."""
 
 
-class FeatureUnavailableError(Exception):
+class FeatureUnavailableError(BelayException):
     """Feature unavailable for your board's implementation."""
 
 
-class SpecialFunctionNameError(Exception):
+class SpecialFunctionNameError(BelayException):
     """Reserved function name that may impact Belay functionality.
 
     Currently limited to:
@@ -17,9 +21,9 @@ class SpecialFunctionNameError(Exception):
     """
 
 
-class ReconstructionError(Exception):
+class ReconstructionError(BelayException):
     """Too many commands were given."""
 
 
-class ConnectionLost(Exception):
+class ConnectionLost(BelayException):
     """Lost connection to device."""

--- a/belay/exceptions.py
+++ b/belay/exceptions.py
@@ -1,5 +1,5 @@
 class BelayException(Exception):
-    """Root Belay Exception class."""
+    """Root Belay exception class."""
 
 
 class AuthenticationError(BelayException):

--- a/belay/pyboard.py
+++ b/belay/pyboard.py
@@ -304,7 +304,6 @@ class Pyboard:
             if serial.__version__ >= "3.3":
                 serial_kwargs["exclusive"] = exclusive
 
-            delayed = False
             for _ in range(attempts):
                 try:
                     self.serial = serial.Serial(device, **serial_kwargs)
@@ -312,14 +311,9 @@ class Pyboard:
                 except (OSError, IOError):  # Py2 and Py3 have different errors
                     if attempts == 1:
                         continue
-                    delayed = True
                 time.sleep(2.0)
             else:
-                if delayed:
-                    print("")
                 raise PyboardError("failed to access " + device)
-            if delayed:
-                print("")
 
     def close(self):
         self.serial.close()

--- a/belay/pyboard.py
+++ b/belay/pyboard.py
@@ -271,9 +271,15 @@ class Pyboard:
         baudrate=115200,
         user="micro",
         password="python",
-        wait=0,
+        attempts=1,
         exclusive=True,
     ):
+        """
+        Parameters
+        ----------
+        wait: int
+            (N-1) of attempts to try and connect
+        """
         self.in_raw_repl = False
         self.use_raw_paste = True
         if device.startswith("exec:"):
@@ -299,19 +305,15 @@ class Pyboard:
                 serial_kwargs["exclusive"] = exclusive
 
             delayed = False
-            for attempt in range(wait + 1):
+            for _ in range(attempts):
                 try:
                     self.serial = serial.Serial(device, **serial_kwargs)
                     break
                 except (OSError, IOError):  # Py2 and Py3 have different errors
-                    if wait == 0:
+                    if attempts == 1:
                         continue
-                    if attempt == 0:
-                        sys.stdout.write("Waiting {} seconds for pyboard ".format(wait))
-                        delayed = True
-                time.sleep(1)
-                sys.stdout.write(".")
-                sys.stdout.flush()
+                    delayed = True
+                time.sleep(2.0)
             else:
                 if delayed:
                     print("")

--- a/belay/pyboard.py
+++ b/belay/pyboard.py
@@ -311,7 +311,7 @@ class Pyboard:
                 except (OSError, IOError):  # Py2 and Py3 have different errors
                     if attempts == 1:
                         continue
-                time.sleep(2.0)
+                time.sleep(1.0)
             else:
                 raise PyboardError("failed to access " + device)
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=
-SPHINXBUILD   ?= sphinx-build
+SPHINXBUILD   ?= poetry run sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 


### PR DESCRIPTION
Problem: Device (for some reason) disconnects, and we want to recover when possible.

Solution:
1. Record all non-task-execution calls to a history.
2. Upon disconnect, attempt to re-connect (in accordance to `attempts`)
3. If reconnection is made, replay the history.


For projects where the board is just a hardware interface (main purpose of Belay), this will get the board back into a state where it can read sensors/output to actuators. If the project requires a more complicated internal device state, this won't really help.