### PR TITLE
Add 'identify' cli command

### DIFF
--- a/belay/cli/main.py
+++ b/belay/cli/main.py
@@ -1,5 +1,6 @@
 from functools import partial
 from pathlib import Path
+from time import sleep
 
 import typer
 from rich.console import Console
@@ -62,8 +63,69 @@ def info(
         help="Password for communication methods (like WebREPL) that require authentication.",
     ),
 ):
+    """Display device firmware information."""
     device = belay.Device(port, password=password)
     version_str = "v" + ".".join(str(x) for x in device.implementation.version)
     print(
         f"{device.implementation.name} {version_str} - {device.implementation.platform}"
     )
+    return device
+
+
+@app.command()
+def identify(
+    port: str = Arg(
+        help="Port (like /dev/ttyUSB0) or WebSocket (like ws://192.168.1.100) of device."
+    ),
+    pin: int = Arg(help="GPIO pin to flash LED on."),
+    password: str = Opt(
+        "",
+        help="Password for communication methods (like WebREPL) that require authentication.",
+    ),
+    neopixel: bool = Option(False, help="Indicator is a neopixel."),
+):
+    """Display device firmware information and blink an LED."""
+    device = info(port=port, password=password)
+
+    if device.implementation.name == "circuitpython":
+        device(f"led = digitalio.DigitalInOut(board.GP{pin})")
+        device("led.direction = digitalio.Direction.OUTPUT")
+
+        if neopixel:
+            device("from neopixel_write import neopixel_write")
+
+            @device.task
+            def set_led(state):
+                val = (255, 255, 255) if state else (0, 0, 0)
+                val = bytearray(val)
+                neopixel_write(led, val)  # noqa: F821
+
+        else:
+
+            @device.task
+            def set_led(state):
+                led.value = state  # noqa: F821
+
+    else:
+        device(f"led = Pin({pin}, Pin.OUT)")
+
+        if neopixel:
+            device("import neopixel")
+            device("pixel = neopixel.NeoPixel(led, 1)")
+
+            @device.task
+            def set_led(state):
+                pixel[0] = (255, 255, 255) if state else (0, 0, 0)  # noqa: F821
+                pixel.write()  # noqa: F821
+
+        else:
+
+            @device.task
+            def set_led(state):
+                led.value(state)  # noqa: F821
+
+    while True:
+        set_led(True)
+        sleep(0.5)
+        set_led(False)
+        sleep(0.5)


### PR DESCRIPTION
Blinks LED on board. Useful for identifying which board is associated with which port name.