### PR TITLE
Mpy cross sync

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,14 +1,4 @@
 coverage:
   status:
-    project:
-      default:
-        # Commits pushed to main should not make the overall
-        # project coverage decrease by more than 1%
-        target: auto
-        threshold: 1%
-    patch:
-      default:
-        # Be tolerant on code coverage diff on PRs to limit
-        # noisy red coverage status on github PRs.
-        target: auto
-        threshold: 20%
+    project: off
+    patch: off

--- a/belay/cli/__init__.py
+++ b/belay/cli/__init__.py
@@ -1,0 +1,1 @@
+from .main import exec, identify, info, run, sync

--- a/belay/cli/__init__.py
+++ b/belay/cli/__init__.py
@@ -1,1 +1,1 @@
-from .main import exec, identify, info, run, sync
+from .main import app, exec, identify, info, run, sync

--- a/belay/cli/main.py
+++ b/belay/cli/main.py
@@ -50,6 +50,10 @@ def sync(
     ),
 ):
     """Synchronize a folder to device."""
+    # Typer issues: https://github.com/tiangolo/typer/issues/410
+    keep = keep if keep else None
+    ignore = ignore if ignore else None
+
     with Progress() as progress:
         task_id = progress.add_task("")
         progress_update = partial(progress.update, task_id)

--- a/belay/cli/main.py
+++ b/belay/cli/main.py
@@ -42,6 +42,7 @@ def sync(
         help="Password for communication methods (like WebREPL) that require authentication.",
     ),
     keep: Optional[List[str]] = Opt(None, help="Files to keep."),
+    ignore: Optional[List[str]] = Opt(None, help="Files to ignore."),
     mpy_cross_binary: Path = Opt("", help="Compile py files with this executable."),
 ):
     """Synchronize a folder to device."""
@@ -56,6 +57,7 @@ def sync(
             folder,
             dst=dst,
             keep=keep,
+            ignore=ignore,
             mpy_cross_binary=mpy_cross_binary,
             progress_update=progress_update,
         )

--- a/belay/cli/main.py
+++ b/belay/cli/main.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.progress import Progress
 from typer import Argument, Option
 
-import belay
+from belay import Device
 
 Arg = partial(Argument, ..., show_default=False)
 Opt = partial(Option)
@@ -45,14 +45,16 @@ def sync(
     password: str = Opt("", help=_help_password),
     keep: Optional[List[str]] = Opt(None, help="Files to keep."),
     ignore: Optional[List[str]] = Opt(None, help="Files to ignore."),
-    mpy_cross_binary: Path = Opt("", help="Compile py files with this executable."),
+    mpy_cross_binary: Optional[Path] = Opt(
+        None, help="Compile py files with this executable."
+    ),
 ):
     """Synchronize a folder to device."""
     with Progress() as progress:
         task_id = progress.add_task("")
         progress_update = partial(progress.update, task_id)
         progress_update(description=f"Connecting to {port}")
-        device = belay.Device(port, password=password)
+        device = Device(port, password=password)
         progress_update(description=f"Connected to {port}.")
 
         device.sync(
@@ -74,7 +76,7 @@ def run(
     password: str = Opt("", help=_help_password),
 ):
     """Run file on-device."""
-    device = belay.Device(port, password=password)
+    device = Device(port, password=password)
     content = file.read_text()
     device(content)
 
@@ -86,7 +88,7 @@ def exec(
     password: str = Opt("", help=_help_password),
 ):
     """Execute python statement on-device."""
-    device = belay.Device(port, password=password)
+    device = Device(port, password=password)
     device(statement)
 
 
@@ -96,7 +98,7 @@ def info(
     password: str = Opt("", help=_help_password),
 ):
     """Display device firmware information."""
-    device = belay.Device(port, password=password)
+    device = Device(port, password=password)
     version_str = "v" + ".".join(str(x) for x in device.implementation.version)
     print(
         f"{device.implementation.name} {version_str} - {device.implementation.platform}"

--- a/belay/cli/main.py
+++ b/belay/cli/main.py
@@ -36,6 +36,7 @@ def sync(
         help="Port (like /dev/ttyUSB0) or WebSocket (like ws://192.168.1.100) of device."
     ),
     folder: Path = Arg(help="Path to folder to sync."),
+    dst: str = Opt("/", help="Destination directory to sync folder contents to."),
     password: str = Opt(
         "",
         help="Password for communication methods (like WebREPL) that require authentication.",
@@ -53,9 +54,10 @@ def sync(
 
         device.sync(
             folder,
-            progress_update=progress_update,
+            dst=dst,
             keep=keep,
             mpy_cross_binary=mpy_cross_binary,
+            progress_update=progress_update,
         )
 
         progress_update(description="Sync complete.")

--- a/belay/cli/main.py
+++ b/belay/cli/main.py
@@ -1,7 +1,7 @@
 from functools import partial
 from pathlib import Path
 from time import sleep
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import typer
 from rich.console import Console
@@ -16,6 +16,13 @@ Opt = partial(Option)
 app = typer.Typer()
 state = {}
 console: Console
+
+_help_port = (
+    "Port (like /dev/ttyUSB0) or WebSocket (like ws://192.168.1.100) of device."
+)
+_help_password = (  # nosec
+    "Password for communication methods (like WebREPL) that require authentication."
+)
 
 
 @app.callback()
@@ -32,15 +39,10 @@ def callback(silent: bool = False):
 
 @app.command()
 def sync(
-    port: str = Arg(
-        help="Port (like /dev/ttyUSB0) or WebSocket (like ws://192.168.1.100) of device."
-    ),
-    folder: Path = Arg(help="Path to folder to sync."),
-    dst: str = Opt("/", help="Destination directory to sync folder contents to."),
-    password: str = Opt(
-        "",
-        help="Password for communication methods (like WebREPL) that require authentication.",
-    ),
+    port: str = Arg(help=_help_port),
+    folder: Path = Arg(help="Path of local file or folder to sync."),
+    dst: str = Opt("/", help="Destination directory to unpack folder contents to."),
+    password: str = Opt("", help=_help_password),
     keep: Optional[List[str]] = Opt(None, help="Files to keep."),
     ignore: Optional[List[str]] = Opt(None, help="Files to ignore."),
     mpy_cross_binary: Path = Opt("", help="Compile py files with this executable."),
@@ -66,14 +68,32 @@ def sync(
 
 
 @app.command()
+def run(
+    port: str = Arg(help=_help_port),
+    file: Path = Arg(help="File to run on-device."),
+    password: str = Opt("", help=_help_password),
+):
+    """Run file on-device."""
+    device = belay.Device(port, password=password)
+    content = file.read_text()
+    device(content)
+
+
+@app.command()
+def exec(
+    port: str = Arg(help=_help_port),
+    statement: str = Arg(help="Statement to execute on-device."),
+    password: str = Opt("", help=_help_password),
+):
+    """Execute python statement on-device."""
+    device = belay.Device(port, password=password)
+    device(statement)
+
+
+@app.command()
 def info(
-    port: str = Arg(
-        help="Port (like /dev/ttyUSB0) or WebSocket (like ws://192.168.1.100) of device."
-    ),
-    password: str = Opt(
-        "",
-        help="Password for communication methods (like WebREPL) that require authentication.",
-    ),
+    port: str = Arg(help=_help_port),
+    password: str = Opt("", help=_help_password),
 ):
     """Display device firmware information."""
     device = belay.Device(port, password=password)
@@ -86,14 +106,9 @@ def info(
 
 @app.command()
 def identify(
-    port: str = Arg(
-        help="Port (like /dev/ttyUSB0) or WebSocket (like ws://192.168.1.100) of device."
-    ),
+    port: str = Arg(help=_help_port),
     pin: int = Arg(help="GPIO pin to flash LED on."),
-    password: str = Opt(
-        "",
-        help="Password for communication methods (like WebREPL) that require authentication.",
-    ),
+    password: str = Opt("", help=_help_password),
     neopixel: bool = Option(False, help="Indicator is a neopixel."),
 ):
     """Display device firmware information and blink an LED."""

--- a/belay/cli/main.py
+++ b/belay/cli/main.py
@@ -1,6 +1,7 @@
 from functools import partial
 from pathlib import Path
 from time import sleep
+from typing import List, Optional
 
 import typer
 from rich.console import Console
@@ -39,6 +40,8 @@ def sync(
         "",
         help="Password for communication methods (like WebREPL) that require authentication.",
     ),
+    keep: Optional[List[str]] = Opt(None, help="Files to keep."),
+    mpy_cross_binary: Path = Opt("", help="Compile py files with this executable."),
 ):
     """Synchronize a folder to device."""
     with Progress() as progress:
@@ -48,7 +51,12 @@ def sync(
         device = belay.Device(port, password=password)
         progress_update(description=f"Connected to {port}.")
 
-        device.sync(folder, progress_update=progress_update)
+        device.sync(
+            folder,
+            progress_update=progress_update,
+            keep=keep,
+            mpy_cross_binary=mpy_cross_binary,
+        )
 
         progress_update(description="Sync complete.")
 

--- a/belay/device.py
+++ b/belay/device.py
@@ -336,8 +336,10 @@ def _preprocess_keep(
         keep = [keep]
     elif isinstance(keep, (list, tuple)):
         pass
-    else:
+    elif isinstance(keep, bool):
         keep = []
+    else:
+        raise ValueError
     keep = [str(dst / Path(x)) for x in keep]
     return keep
 

--- a/belay/device.py
+++ b/belay/device.py
@@ -46,10 +46,10 @@ def _read_snippet(name):
 
 
 def _local_hash_file(fn: Union[str, Path]) -> int:
-    """Compute the FNV-1a 64-bit hash of a file."""
+    """Compute the FNV-1a 32-bit hash of a file."""
     fn = Path(fn)
-    h = 0xCBF29CE484222325
-    size = 1 << 64
+    h = 0x811C9DC5
+    size = 1 << 32
     with fn.open("rb") as f:
         while True:
             data = f.read(65536)
@@ -57,7 +57,7 @@ def _local_hash_file(fn: Union[str, Path]) -> int:
                 break
             for byte in data:
                 h = h ^ byte
-                h = (h * 0x100000001B3) % size
+                h = (h * 0x01000193) % size
     return h
 
 

--- a/belay/device.py
+++ b/belay/device.py
@@ -514,8 +514,6 @@ class Device:
 
         if not folder.exists():
             raise ValueError(f'"{folder}" does not exist.')
-        if not folder.is_dir():
-            raise ValueError(f'"{folder}" is not a directory.')
 
         # Create a list of all files and dirs (on-device).
         # This is so we know what to clean up after done syncing.
@@ -540,11 +538,14 @@ class Device:
                 keep_all = True
             keep = []
 
-        if keep_all or folder.is_file():
+        if keep_all:
             # Don't build up the device of files, we won't be deleting anything
             self("del __belay_fs")
         else:
-            self("__belay_fs(); all_dirs.sort(); del __belay_fs")
+            if dst == "/":
+                self("__belay_fs(); all_dirs.sort(); del __belay_fs")
+            else:
+                self(f"__belay_fs({repr(dst)}); all_dirs.sort(); del __belay_fs")
             keep = [str(dst / Path(x)) for x in keep]
 
         if ignore is None:

--- a/belay/device.py
+++ b/belay/device.py
@@ -468,7 +468,7 @@ class Device:
         self,
         folder: Union[str, Path],
         dst: str = "/",
-        keep: Union[None, list, str] = None,
+        keep: Union[None, list, str, bool] = None,
         ignore: Union[None, list, str] = None,
         minify: bool = True,
         mpy_cross_binary: Union[str, Path] = "",

--- a/belay/device.py
+++ b/belay/device.py
@@ -675,6 +675,9 @@ class Device:
                 if src_hash != dst_hash:
                     puts.append((src_file, dst_file))
 
+            if progress_update:
+                progress_update(total=len(puts))
+
             for src_file, dst_file in puts:
                 if progress_update:
                     progress_update(description=f"Pushing: {dst_file[1:]}")

--- a/belay/device.py
+++ b/belay/device.py
@@ -644,7 +644,7 @@ class Device:
             raise Exception
 
         if progress_update:
-            progress_update(total=len(src_files))
+            progress_update(total=len(src_files), description="Pushing files...")
         for src_file, dst_file, dst_hash in zip(src_files, dst_files, dst_hashes):
             with tempfile.TemporaryDirectory() as tmp_dir:
                 src_file = _preprocess_src_file(

--- a/belay/device.py
+++ b/belay/device.py
@@ -45,11 +45,12 @@ def _read_snippet(name):
     return pkg_resources.read_text(snippets, f"{name}.py")
 
 
-def _local_hash_file(fn: str) -> int:
+def _local_hash_file(fn: Union[str, Path]) -> int:
     """Compute the FNV-1a 64-bit hash of a file."""
+    fn = Path(fn)
     h = 0xCBF29CE484222325
     size = 1 << 64
-    with open(fn, "rb") as f:  # noqa: PL123
+    with fn.open("rb") as f:
         while True:
             data = f.read(65536)
             if not data:
@@ -405,7 +406,7 @@ class Device:
         minify: bool = True,
         stream_out: TextIO = sys.stdout,
         record=True,
-    ) -> BelayReturn:
+    ):
         """Execute code on-device.
 
         Parameters

--- a/belay/device.py
+++ b/belay/device.py
@@ -371,6 +371,16 @@ def _preprocess_src_file(tmp_dir: Union[str, Path], src_file, minify, mpy_cross_
     return src_file
 
 
+def _generate_dst_dirs(dst, src, src_dirs) -> list:
+    dst_dirs = [str(dst / x.relative_to(src)) for x in src_dirs]
+    # Add all directories leading up to ``dst``.
+    dst_prefix_tokens = dst.split("/")
+    for i in range(2, len(dst_prefix_tokens) + (dst[-1] != "/")):
+        dst_dirs.append("/".join(dst_prefix_tokens[:i]))
+    dst_dirs.sort()
+    return dst_dirs
+
+
 @dataclass
 class Implementation:
     """Implementation dataclass detailing the device.
@@ -603,13 +613,7 @@ class Device:
                 for dst_file in dst_files
             ]
         dst_files = [str(dst_file) for dst_file in dst_files]
-
-        dst_dirs = [str(dst / src.relative_to(folder)) for src in src_dirs]
-        # Add all directories leading up to ``dst``.
-        dst_prefix_tokens = dst.split("/")
-        for i in range(2, len(dst_prefix_tokens) + (dst[-1] != "/")):
-            dst_dirs.append("/".join(dst_prefix_tokens[:i]))
-        dst_dirs.sort()
+        dst_dirs = _generate_dst_dirs(dst, folder, src_dirs)
 
         if not keep_all:
             # prevent keep duplicates in the concat'd file list

--- a/belay/device.py
+++ b/belay/device.py
@@ -471,7 +471,7 @@ class Device:
         keep: Union[None, list, str, bool] = None,
         ignore: Union[None, list, str] = None,
         minify: bool = True,
-        mpy_cross_binary: Union[str, Path] = "",
+        mpy_cross_binary: Union[str, Path, None] = None,
         progress_update=None,
     ) -> None:
         """Sync a local directory to the remote filesystem.
@@ -498,7 +498,7 @@ class Device:
         minify: bool
             Minify python files prior to syncing.
             Defaults to ``True``.
-        mpy_cross_binary: Union[str, Path]
+        mpy_cross_binary: Union[str, Path, None]
             Path to mpy-cross binary. If provided, ``.py`` will automatically
             be compiled.
             Takes precedence over minifying.

--- a/belay/device.py
+++ b/belay/device.py
@@ -485,7 +485,8 @@ class Device:
         folder: str, Path
             Directory of files to sync to the root of the board's filesystem.
         dst: str
-            Destination directory on device. Defaults to unpacking ``folder`` to root.
+            Destination **directory** on device.
+            Defaults to unpacking ``folder`` to root.
         keep: None | str | list | bool
             Do NOT delete these file(s) on-device if not present in ``folder``.
             If ``true``, don't delete any files on device.

--- a/belay/device.py
+++ b/belay/device.py
@@ -356,8 +356,14 @@ def _preprocess_ignore(ignore: Union[None, str, list, tuple]) -> list:
     return ignore
 
 
-def _preprocess_src_file(tmp_dir: Union[str, Path], src_file, minify, mpy_cross_binary):
+def _preprocess_src_file(
+    tmp_dir: Union[str, Path],
+    src_file: Union[str, Path],
+    minify: bool,
+    mpy_cross_binary: Union[str, Path, None],
+) -> Path:
     tmp_dir = Path(tmp_dir)
+    src_file = Path(src_file)
 
     if src_file.suffix == ".py":
         if mpy_cross_binary:
@@ -640,15 +646,15 @@ class Device:
         if progress_update:
             progress_update(total=len(src_files))
         for src_file, dst_file, dst_hash in zip(src_files, dst_files, dst_hashes):
-            if progress_update:
-                progress_update(description=f"Syncing: {dst_file[1:]}")
-
             with tempfile.TemporaryDirectory() as tmp_dir:
                 src_file = _preprocess_src_file(
                     tmp_dir, src_file, minify, mpy_cross_binary
                 )
                 src_hash = _local_hash_file(src_file)
                 if src_hash != dst_hash:
+                    if progress_update:
+                        progress_update(description=f"Pushing: {dst_file[1:]}")
+
                     self._board.fs_put(src_file, dst_file)
 
             if progress_update:

--- a/belay/snippets/sync_begin.py
+++ b/belay/snippets/sync_begin.py
@@ -32,19 +32,20 @@ def __belay_mkdirs(fns):
         except OSError:
             pass
 all_files, all_dirs = set(), []
-def __belay_fs(path="/"):
+def __belay_fs(path="/", check=True):
     if not path:
         path = "/"
     elif not path.endswith("/"):
         path += "/"
-    try:
-        os.stat(path)
-    except OSError:
-        return
-    for elem in os.listdir(path):
-        full_name = path + elem
-        if os.stat(full_name)[0] & 0x4000:  # is_dir
+    if check:
+        try:
+            os.stat(path)
+        except OSError:
+            return
+    for elem in os.ilistdir(path):
+        full_name = path + elem[0]
+        if elem[1] & 0x4000:  # is_dir
             all_dirs.append(full_name)
-            __belay_fs(full_name)
+            __belay_fs(full_name, check=False)
         else:
             all_files.add(full_name)

--- a/belay/snippets/sync_begin.py
+++ b/belay/snippets/sync_begin.py
@@ -27,11 +27,8 @@ all_files, all_dirs = set(), []
 def __belay_fs(path=""):
     for elem in os.listdir(path):
         full_name = path + "/" + elem
-        try:
-            if os.stat(elem)[0] & 0x4000:  # is_dir
-                all_dirs.append(full_name)
-                __belay_fs(full_name)
-            else:
-                all_files.add(full_name)
-        except OSError:
-            pass
+        if os.stat(full_name)[0] & 0x4000:  # is_dir
+            all_dirs.append(full_name)
+            __belay_fs(full_name)
+        else:
+            all_files.add(full_name)

--- a/belay/snippets/sync_begin.py
+++ b/belay/snippets/sync_begin.py
@@ -35,6 +35,3 @@ def __belay_fs(path=""):
                 all_files.add(full_name)
         except OSError:
             pass
-__belay_fs()
-all_dirs.sort()
-del __belay_fs

--- a/belay/snippets/sync_begin.py
+++ b/belay/snippets/sync_begin.py
@@ -25,6 +25,10 @@ def __belay_mkdirs(fns):
             pass
 all_files, all_dirs = set(), []
 def __belay_fs(path=""):
+    try:
+        os.stat(path)
+    except OSError:
+        return
     for elem in os.listdir(path):
         full_name = path + "/" + elem
         if os.stat(full_name)[0] & 0x4000:  # is_dir

--- a/belay/snippets/sync_begin.py
+++ b/belay/snippets/sync_begin.py
@@ -24,13 +24,11 @@ def __belay_mkdirs(fns):
         except OSError:
             pass
 all_files, all_dirs = set(), []
-def __belay_fs(path=""):
-    try:
-        os.stat(path)
-    except OSError:
-        return
+def __belay_fs(path="/"):
+    if not path.endswith("/"):
+        path += "/"
     for elem in os.listdir(path):
-        full_name = path + "/" + elem
+        full_name = path + elem
         if os.stat(full_name)[0] & 0x4000:  # is_dir
             all_dirs.append(full_name)
             __belay_fs(full_name)

--- a/belay/snippets/sync_begin.py
+++ b/belay/snippets/sync_begin.py
@@ -29,6 +29,10 @@ def __belay_fs(path="/"):
         path = "/"
     elif not path.endswith("/"):
         path += "/"
+    try:
+        os.stat(path)
+    except OSError:
+        return
     for elem in os.listdir(path):
         full_name = path + elem
         if os.stat(full_name)[0] & 0x4000:  # is_dir

--- a/belay/snippets/sync_begin.py
+++ b/belay/snippets/sync_begin.py
@@ -1,22 +1,30 @@
 # Creates and populates two set[str]: all_files, all_dirs
 import os
-def __belay_hf(fn):
-    h = 0xcbf29ce484222325
-    size = 1 << 64
+import micropython
+@micropython.native
+def __belay_hf(fn, buf):
+    # inherently is inherently modulo 32-bit arithmetic
+    @micropython.viper
+    def xor_mm(data, state: uint, prime: uint) -> uint:
+        for b in data:
+            state = uint((state ^ uint(b)) * prime)
+        return state
+
+    h = 0x811c9dc5
     try:
-        with open(fn, "rb") as f:
-            while True:
-                data = f.read(4096)
-                if not data:
-                    break
-                for byte in data:
-                    h = h ^ byte
-                    h = (h * 0x100000001b3) % size
+        f = open(fn, "rb")
+        while True:
+            n = f.readinto(buf)
+            if n == 0:
+                break
+            h = xor_mm(buf[:n], h, 0x01000193)
+        f.close()
     except OSError:
-        return 0
+        h = 0
     return h
 def __belay_hfs(fns):
-    print("_BELAYR" + repr([__belay_hf(fn) for fn in fns]))
+    buf = memoryview(bytearray(4096))
+    print("_BELAYR" + repr([__belay_hf(fn, buf) for fn in fns]))
 def __belay_mkdirs(fns):
     for fn in fns:
         try:

--- a/belay/snippets/sync_begin.py
+++ b/belay/snippets/sync_begin.py
@@ -25,7 +25,9 @@ def __belay_mkdirs(fns):
             pass
 all_files, all_dirs = set(), []
 def __belay_fs(path="/"):
-    if not path.endswith("/"):
+    if not path:
+        path = "/"
+    elif not path.endswith("/"):
         path += "/"
     for elem in os.listdir(path):
         full_name = path + elem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ python = "^3.8"
 pyserial = "^3.1"
 typer = {extras = ["all"], version = "^0.6"}
 pathspec = "*"
+lox = "^0.11.0"
 
 [tool.poetry.group.docs.dependencies]
 sphinx = "~4.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ belay = "belay.cli.main:app"
 python = "^3.8"
 pyserial = "^3.1"
 typer = {extras = ["all"], version = "^0.6"}
+pathspec = "*"
 
 [tool.poetry.group.docs.dependencies]
 sphinx = "~4.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ pre_commit = "^2.16.0"
 pytest = "^7.1.2"
 pytest-cov = "^3.0.0"
 pytest-mock = "^3.7.0"
+line_profiler = "^3.5.1"
 
 [tool.coverage.run]
 branch = true

--- a/tests/cli/test_exec.py
+++ b/tests/cli/test_exec.py
@@ -1,0 +1,5 @@
+def test_exec_basic(mocker, mock_device, cli_runner):
+    mock_device.patch("belay.cli.main.Device")
+    result = cli_runner("exec", "print('hello world')")
+    assert result.exit_code == 0
+    mock_device.inst.assert_called_once_with("print('hello world')")

--- a/tests/cli/test_info.py
+++ b/tests/cli/test_info.py
@@ -1,0 +1,8 @@
+def test_info_basic(mocker, mock_device, cli_runner, tmp_path):
+    mock_device.patch("belay.cli.main.Device")
+    mock_device.inst.implementation.name = "testingpython"
+    mock_device.inst.implementation.version = (4, 7, 9)
+    mock_device.inst.implementation.platform = "pytest"
+    result = cli_runner("info")
+    assert result.exit_code == 0
+    assert result.output == "testingpython v4.7.9 - pytest\n"

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,6 +1,3 @@
-from pathlib import PosixPath
-
-
 def test_run_basic(mocker, mock_device, cli_runner, tmp_path):
     mock_device.patch("belay.cli.main.Device")
     py_file = tmp_path / "foo.py"

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,0 +1,10 @@
+from pathlib import PosixPath
+
+
+def test_run_basic(mocker, mock_device, cli_runner, tmp_path):
+    mock_device.patch("belay.cli.main.Device")
+    py_file = tmp_path / "foo.py"
+    py_file.write_text("print('hello')\nprint('world')")
+    result = cli_runner("run", str(py_file))
+    assert result.exit_code == 0
+    mock_device.inst.assert_called_once_with("print('hello')\nprint('world')")

--- a/tests/cli/test_sync.py
+++ b/tests/cli/test_sync.py
@@ -1,0 +1,31 @@
+from collections import namedtuple
+from pathlib import PosixPath
+
+import pytest
+from typer.testing import CliRunner
+
+from belay.cli import app
+
+runner = CliRunner()
+MockDevice = namedtuple("MockDevice", ["cls", "inst"])
+
+
+@pytest.fixture
+def mock_device(mocker):
+    mock_instance = mocker.MagicMock()
+    mock_class = mocker.patch("belay.cli.main.Device", return_value=mock_instance)
+    return MockDevice(mock_class, mock_instance)
+
+
+def test_sync_basic(mocker, mock_device):
+    result = runner.invoke(app, ["sync", "/dev/ttyUSB0", "foo"])
+    assert result.exit_code == 0
+    mock_device.cls.assert_called_once_with("/dev/ttyUSB0", password="")
+    mock_device.inst.sync.assert_called_once_with(
+        PosixPath("foo"),
+        dst="/",
+        keep=[],
+        ignore=[],
+        mpy_cross_binary=None,
+        progress_update=mocker.ANY,
+    )

--- a/tests/cli/test_sync.py
+++ b/tests/cli/test_sync.py
@@ -8,8 +8,8 @@ def test_sync_basic(mocker, mock_device, cli_runner):
     mock_device.inst.sync.assert_called_once_with(
         PosixPath("foo"),
         dst="/",
-        keep=[],
-        ignore=[],
+        keep=None,
+        ignore=None,
         mpy_cross_binary=None,
         progress_update=mocker.ANY,
     )

--- a/tests/cli/test_sync.py
+++ b/tests/cli/test_sync.py
@@ -1,26 +1,10 @@
-from collections import namedtuple
 from pathlib import PosixPath
 
-import pytest
-from typer.testing import CliRunner
 
-from belay.cli import app
-
-runner = CliRunner()
-MockDevice = namedtuple("MockDevice", ["cls", "inst"])
-
-
-@pytest.fixture
-def mock_device(mocker):
-    mock_instance = mocker.MagicMock()
-    mock_class = mocker.patch("belay.cli.main.Device", return_value=mock_instance)
-    return MockDevice(mock_class, mock_instance)
-
-
-def test_sync_basic(mocker, mock_device):
-    result = runner.invoke(app, ["sync", "/dev/ttyUSB0", "foo"])
+def test_sync_basic(mocker, mock_device, cli_runner):
+    mock_device.patch("belay.cli.main.Device")
+    result = cli_runner("sync", "foo")
     assert result.exit_code == 0
-    mock_device.cls.assert_called_once_with("/dev/ttyUSB0", password="")
     mock_device.inst.sync.assert_called_once_with(
         PosixPath("foo"),
         dst="/",

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,6 +1,3 @@
-from pathlib import PosixPath
-from unittest.mock import call
-
 import pytest
 
 import belay
@@ -27,7 +24,7 @@ def mock_device(mock_pyboard):
 
 
 def test_device_init(mock_device):
-    pass
+    """Just checks if everything in ``__init__`` is called fine."""
 
 
 def test_device_init_no_startup(mock_pyboard):
@@ -127,134 +124,3 @@ def test_device_traceback_execute(mocker, mock_device, tmp_path):
     with pytest.raises(belay.PyboardException) as exc_info:
         mock_device._traceback_execute(src_file, src_lineno, name, cmd)
     assert exc_info.value.args[0] == expected_msg
-
-
-@pytest.fixture
-def sync_path(tmp_path):
-    (tmp_path / "alpha.py").write_text("def alpha():\n    pass")
-    (tmp_path / "bar.txt").write_text("bar contents")
-    (tmp_path / "foo.txt").write_text("foo contents")
-    (tmp_path / "folder1" / "folder1_1").mkdir(parents=True)
-    (tmp_path / "folder1" / "file1.txt").write_text("file1 contents")
-    (tmp_path / "folder1" / "folder1_1" / "file1_1.txt").write_text("file1_1 contents")
-
-    return tmp_path
-
-
-def test_device_sync_empty_remote(mocker, mock_device, sync_path):
-    payload = ("_BELAYR" + repr([b""] * 5) + "\r\n").encode("utf-8")
-    mock_device._board.exec = mocker.MagicMock(return_value=payload)
-
-    mock_device.sync(sync_path)
-
-    mock_device._board.exec.assert_has_calls(
-        [
-            call(
-                "for x in['/alpha.py','/bar.txt','/folder1/file1.txt','/folder1/folder1_1/file1_1.txt','/foo.txt','/boot.py','/webrepl_cfg.py']:\n all_files.discard(x)"
-            ),
-            call("__belay_mkdirs(['/folder1','/folder1/folder1_1'])"),
-            call(
-                "__belay_hfs(['/alpha.py','/bar.txt','/folder1/file1.txt','/folder1/folder1_1/file1_1.txt','/foo.txt'])"
-            ),
-        ]
-    )
-
-    mock_device._board.fs_put.assert_has_calls(
-        [
-            call(sync_path / "bar.txt", "/bar.txt"),
-            call(sync_path / "folder1/file1.txt", "/folder1/file1.txt"),
-            call(
-                sync_path / "folder1/folder1_1/file1_1.txt",
-                "/folder1/folder1_1/file1_1.txt",
-            ),
-            call(sync_path / "foo.txt", "/foo.txt"),
-        ]
-    )
-
-
-def test_device_sync_partial_remote(mocker, mock_device, sync_path):
-    def __belay_hfs(fns):
-        out = []
-        for fn in fns:
-            local_fn = sync_path / fn[1:]
-            if local_fn.stem.endswith("1"):
-                out.append(b"\x00")
-            else:
-                out.append(belay.device._local_hash_file(local_fn))
-        return out
-
-    def side_effect(cmd):
-        if not cmd.startswith("__belay_hfs"):
-            return b""
-        nonlocal __belay_hfs
-        return ("_BELAYR" + repr(eval(cmd)) + "\r\n").encode("utf-8")
-
-    mock_device._board.exec = mocker.MagicMock(side_effect=side_effect)
-
-    mock_device.sync(sync_path)
-
-    mock_device._board.fs_put.assert_has_calls(
-        [
-            call(sync_path / "folder1/file1.txt", "/folder1/file1.txt"),
-            call(
-                sync_path / "folder1/folder1_1/file1_1.txt",
-                "/folder1/folder1_1/file1_1.txt",
-            ),
-        ]
-    )
-
-
-def test_discover_files_dirs_typical(tmp_path):
-    (tmp_path / "file1.ext").touch()
-    (tmp_path / "file2.ext").touch()
-    (tmp_path / "folder1").mkdir()
-    (tmp_path / "folder1" / "file3.ext").touch()
-
-    remote_dir = "/foo/bar"
-    src_files, src_dirs, dst_files = belay.device._discover_files_dirs(
-        remote_dir=remote_dir,
-        local_file_or_folder=tmp_path,
-    )
-
-    src_files = [x.relative_to(tmp_path) for x in src_files]
-    src_dirs = [x.relative_to(tmp_path) for x in src_dirs]
-    assert src_files == [
-        PosixPath("file1.ext"),
-        PosixPath("file2.ext"),
-        PosixPath("folder1/file3.ext"),
-    ]
-    assert src_dirs == [PosixPath("folder1")]
-    assert dst_files == [
-        PosixPath("/foo/bar/file1.ext"),
-        PosixPath("/foo/bar/file2.ext"),
-        PosixPath("/foo/bar/folder1/file3.ext"),
-    ]
-
-
-def test_discover_files_dirs_empty(tmp_path):
-    remote_dir = "/foo/bar"
-    src_files, src_dirs, dst_files = belay.device._discover_files_dirs(
-        remote_dir=remote_dir,
-        local_file_or_folder=tmp_path,
-    )
-
-    assert src_files == []
-    assert src_dirs == []
-    assert dst_files == []
-
-
-def test_discover_files_dirs_single_file(tmp_path):
-    single_file = tmp_path / "file1.ext"
-    single_file.touch()
-
-    remote_dir = "/foo/bar"
-    src_files, src_dirs, dst_files = belay.device._discover_files_dirs(
-        remote_dir=remote_dir,
-        local_file_or_folder=single_file,
-    )
-
-    src_files = [x.relative_to(tmp_path) for x in src_files]
-    src_dirs = [x.relative_to(tmp_path) for x in src_dirs]
-    assert src_files == [PosixPath("file1.ext")]
-    assert src_dirs == []
-    assert dst_files == [PosixPath("/foo/bar/file1.ext")]

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -124,3 +124,23 @@ def test_device_traceback_execute(mocker, mock_device, tmp_path):
     with pytest.raises(belay.PyboardException) as exc_info:
         mock_device._traceback_execute(src_file, src_lineno, name, cmd)
     assert exc_info.value.args[0] == expected_msg
+
+
+def test_parse_belay_response_unknown():
+    with pytest.raises(ValueError):
+        belay.device._parse_belay_response("_BELAYA")
+
+
+def test_parse_belay_response_stop_iteration():
+    with pytest.raises(StopIteration):
+        belay.device._parse_belay_response("_BELAYS")
+
+
+def test_parse_belay_response_r():
+    assert [1, 2, 3] == belay.device._parse_belay_response("_BELAYR[1,2,3]")
+    assert 1 == belay.device._parse_belay_response("_BELAYR1")
+    assert 1.23 == belay.device._parse_belay_response("_BELAYR1.23")
+    assert "a" == belay.device._parse_belay_response("_BELAYR'a'")
+    assert {1} == belay.device._parse_belay_response("_BELAYR{1}")
+    assert b"foo" == belay.device._parse_belay_response("_BELAYRb'foo'")
+    assert belay.device._parse_belay_response("_BELAYRFalse") is False

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -1,0 +1,157 @@
+from pathlib import PosixPath
+from unittest.mock import call
+
+import pytest
+
+import belay
+import belay.device
+
+
+@pytest.fixture
+def mock_pyboard(mocker):
+    def mock_init(self, *args, **kwargs):
+        self.serial = None
+
+    exec_side_effect = [b'_BELAYR("micropython", (1, 19, 1), "rp2")\r\n'] * 100
+
+    mocker.patch.object(belay.device.Pyboard, "__init__", mock_init)
+    mocker.patch("belay.device.Pyboard.enter_raw_repl", return_value=None)
+    mocker.patch("belay.device.Pyboard.exec", side_effect=exec_side_effect)
+    mocker.patch("belay.device.Pyboard.fs_put")
+
+
+@pytest.fixture
+def mock_device(mock_pyboard):
+    device = belay.Device()
+    return device
+
+
+@pytest.fixture
+def sync_path(tmp_path):
+    (tmp_path / "alpha.py").write_text("def alpha():\n    pass")
+    (tmp_path / "bar.txt").write_text("bar contents")
+    (tmp_path / "foo.txt").write_text("foo contents")
+    (tmp_path / "folder1" / "folder1_1").mkdir(parents=True)
+    (tmp_path / "folder1" / "file1.txt").write_text("file1 contents")
+    (tmp_path / "folder1" / "folder1_1" / "file1_1.txt").write_text("file1_1 contents")
+
+    return tmp_path
+
+
+def test_device_sync_empty_remote(mocker, mock_device, sync_path):
+    payload = ("_BELAYR" + repr([b""] * 5) + "\r\n").encode("utf-8")
+    mock_device._board.exec = mocker.MagicMock(return_value=payload)
+
+    mock_device.sync(sync_path)
+
+    mock_device._board.exec.assert_has_calls(
+        [
+            call(
+                "for x in['/alpha.py','/bar.txt','/folder1/file1.txt','/folder1/folder1_1/file1_1.txt','/foo.txt','/boot.py','/webrepl_cfg.py']:\n all_files.discard(x)"
+            ),
+            call("__belay_mkdirs(['/folder1','/folder1/folder1_1'])"),
+            call(
+                "__belay_hfs(['/alpha.py','/bar.txt','/folder1/file1.txt','/folder1/folder1_1/file1_1.txt','/foo.txt'])"
+            ),
+        ]
+    )
+
+    mock_device._board.fs_put.assert_has_calls(
+        [
+            call(sync_path / "bar.txt", "/bar.txt"),
+            call(sync_path / "folder1/file1.txt", "/folder1/file1.txt"),
+            call(
+                sync_path / "folder1/folder1_1/file1_1.txt",
+                "/folder1/folder1_1/file1_1.txt",
+            ),
+            call(sync_path / "foo.txt", "/foo.txt"),
+        ]
+    )
+
+
+def test_device_sync_partial_remote(mocker, mock_device, sync_path):
+    def __belay_hfs(fns):
+        out = []
+        for fn in fns:
+            local_fn = sync_path / fn[1:]
+            if local_fn.stem.endswith("1"):
+                out.append(b"\x00")
+            else:
+                out.append(belay.device._local_hash_file(local_fn))
+        return out
+
+    def side_effect(cmd):
+        if not cmd.startswith("__belay_hfs"):
+            return b""
+        nonlocal __belay_hfs
+        return ("_BELAYR" + repr(eval(cmd)) + "\r\n").encode("utf-8")
+
+    mock_device._board.exec = mocker.MagicMock(side_effect=side_effect)
+
+    mock_device.sync(sync_path)
+
+    mock_device._board.fs_put.assert_has_calls(
+        [
+            call(sync_path / "folder1/file1.txt", "/folder1/file1.txt"),
+            call(
+                sync_path / "folder1/folder1_1/file1_1.txt",
+                "/folder1/folder1_1/file1_1.txt",
+            ),
+        ]
+    )
+
+
+def test_discover_files_dirs_typical(tmp_path):
+    (tmp_path / "file1.ext").touch()
+    (tmp_path / "file2.ext").touch()
+    (tmp_path / "folder1").mkdir()
+    (tmp_path / "folder1" / "file3.ext").touch()
+
+    remote_dir = "/foo/bar"
+    src_files, src_dirs, dst_files = belay.device._discover_files_dirs(
+        remote_dir=remote_dir,
+        local_file_or_folder=tmp_path,
+    )
+
+    src_files = [x.relative_to(tmp_path) for x in src_files]
+    src_dirs = [x.relative_to(tmp_path) for x in src_dirs]
+    assert src_files == [
+        PosixPath("file1.ext"),
+        PosixPath("file2.ext"),
+        PosixPath("folder1/file3.ext"),
+    ]
+    assert src_dirs == [PosixPath("folder1")]
+    assert dst_files == [
+        PosixPath("/foo/bar/file1.ext"),
+        PosixPath("/foo/bar/file2.ext"),
+        PosixPath("/foo/bar/folder1/file3.ext"),
+    ]
+
+
+def test_discover_files_dirs_empty(tmp_path):
+    remote_dir = "/foo/bar"
+    src_files, src_dirs, dst_files = belay.device._discover_files_dirs(
+        remote_dir=remote_dir,
+        local_file_or_folder=tmp_path,
+    )
+
+    assert src_files == []
+    assert src_dirs == []
+    assert dst_files == []
+
+
+def test_discover_files_dirs_single_file(tmp_path):
+    single_file = tmp_path / "file1.ext"
+    single_file.touch()
+
+    remote_dir = "/foo/bar"
+    src_files, src_dirs, dst_files = belay.device._discover_files_dirs(
+        remote_dir=remote_dir,
+        local_file_or_folder=single_file,
+    )
+
+    src_files = [x.relative_to(tmp_path) for x in src_files]
+    src_dirs = [x.relative_to(tmp_path) for x in src_dirs]
+    assert src_files == [PosixPath("file1.ext")]
+    assert src_dirs == []
+    assert dst_files == [PosixPath("/foo/bar/file1.ext")]

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -44,11 +44,19 @@ def sync_begin():
     exec(belay.device._read_snippet("sync_begin"), globals())
 
 
-def test_sync_device_belay_hf(sync_begin, tmp_path):
-    """Test on-device FNV-1a hash implementation.
+def test_sync_local_belay_hf(sync_begin, tmp_path):
+    """Test local FNV-1a hash implementation.
 
     Test vector from: http://www.isthe.com/chongo/src/fnv/test_fnv.c
     """
+    f = tmp_path / "test_file"
+    f.write_text("foobar")
+    actual = belay.device._local_hash_file(f)
+    assert actual == 0x85944171F73967E8
+
+
+def test_sync_device_belay_hf(sync_begin, tmp_path):
+    """Test on-device FNV-1a hash implementation."""
     f = tmp_path / "test_file"
     f.write_text("foobar")
     actual = __belay_hf(str(f))  # noqa: F821

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -1,4 +1,5 @@
 import ast
+import os
 from pathlib import Path, PosixPath
 from unittest.mock import call
 
@@ -11,6 +12,12 @@ import belay.device
 def uint(x):
     """For patching micropython.viper code for testing."""
     return x % (1 << 32)
+
+
+def ilistdir(x):
+    for name in os.listdir(x):
+        stat = os.stat(x + "/" + name)  # noqa: PL116
+        yield (name, stat.st_mode, stat.st_ino)
 
 
 @pytest.fixture
@@ -51,6 +58,7 @@ def sync_begin():
     lines = snippet.split("\n")
     lines = [x for x in lines if "micropython" not in x]
     snippet = "\n".join(lines)
+    snippet = snippet.replace("os.ilistdir", "ilistdir")
     exec(snippet, globals())
 
 

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -1,5 +1,5 @@
 import ast
-from pathlib import PosixPath
+from pathlib import Path, PosixPath
 from unittest.mock import call
 
 import pytest
@@ -88,8 +88,27 @@ def test_sync_device_belay_mkdirs(sync_begin, tmp_path):
     assert (tmp_path / "bar1" / "bar2").is_dir()
 
 
-def test_sync_device_belay_fs(sync_begin):
-    pass
+def test_sync_device_belay_fs_basic(sync_begin, tmp_path):
+    expected_files = {
+        tmp_path / "foo1" / "foo2" / "foo_file.py",
+        tmp_path / "bar1" / "bar2" / "bar_file.py",
+    }
+    expected_dirs = {
+        tmp_path / "foo1",
+        tmp_path / "foo1" / "foo2",
+        tmp_path / "bar1",
+        tmp_path / "bar1" / "bar2",
+    }
+    for f in expected_files:
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.touch()
+
+    __belay_fs(str(tmp_path))  # noqa: F821
+    _all_files = {Path(x) for x in all_files}  # noqa: F821
+    _all_dirs = {Path(x) for x in all_dirs}  # noqa: F821
+
+    assert _all_files == expected_files
+    assert _all_dirs == expected_dirs
 
 
 def test_device_sync_empty_remote(mocker, mock_device, sync_path):

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -283,8 +283,16 @@ def test_preprocess_ignore_str():
     assert actual == ["foo"]
 
 
-def test_preprocess_src_file():
-    pass
+def test_preprocess_src_file_default_py(tmp_path):
+    actual = belay.device._preprocess_src_file(tmp_path, "foo/bar/baz.py", False, None)
+    assert actual == Path("foo/bar/baz.py")
+
+
+def test_preprocess_src_file_default_generic(tmp_path):
+    actual = belay.device._preprocess_src_file(
+        tmp_path, "foo/bar/baz.generic", False, None
+    )
+    assert actual == Path("foo/bar/baz.generic")
 
 
 def test_generate_dst_dirs():

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -38,6 +38,29 @@ def sync_path(tmp_path):
     return tmp_path
 
 
+@pytest.fixture
+def sync_begin():
+    _globals, _locals = {}, {}
+    exec(belay.device._read_snippet("sync_begin"), _globals, _locals)
+    return _locals
+
+
+def test_sync_device_belay_hf(sync_begin):
+    pass
+
+
+def test_sync_device_belay_hfs(sync_begin):
+    pass
+
+
+def test_sync_device_belay_mkdirs(sync_begin):
+    pass
+
+
+def test_sync_device_belay_fs(sync_begin):
+    pass
+
+
 def test_device_sync_empty_remote(mocker, mock_device, sync_path):
     payload = ("_BELAYR" + repr([b""] * 5) + "\r\n").encode("utf-8")
     mock_device._board.exec = mocker.MagicMock(return_value=payload)

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -71,8 +71,21 @@ def test_sync_device_belay_hfs(sync_begin, capsys, tmp_path):
     assert captured.out == "_BELAYR[14610070471194899466, 9625390261332436968]\n"
 
 
-def test_sync_device_belay_mkdirs(sync_begin):
-    pass
+def test_sync_device_belay_mkdirs(sync_begin, tmp_path):
+    paths = [
+        tmp_path,
+        tmp_path / "foo1",
+        tmp_path / "foo1" / "foo2",
+        tmp_path / "bar1",
+        tmp_path / "bar1" / "bar2",
+    ]
+    paths = [str(x) for x in paths]
+    __belay_mkdirs(paths)  # noqa: F821
+    assert (tmp_path).is_dir()
+    assert (tmp_path / "foo1").is_dir()
+    assert (tmp_path / "foo1" / "foo2").is_dir()
+    assert (tmp_path / "bar1").is_dir()
+    assert (tmp_path / "bar1" / "bar2").is_dir()
 
 
 def test_sync_device_belay_fs(sync_begin):

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -119,6 +119,13 @@ def test_sync_device_belay_fs_basic(sync_begin, tmp_path):
     assert _all_dirs == expected_dirs
 
 
+def test_sync_device_belay_fs_does_not_exist(sync_begin, tmp_path):
+    non_existing_dir = tmp_path / "does_not_exist"
+    __belay_fs(str(non_existing_dir))  # noqa: F821
+    assert all_files == set()  # noqa: F821
+    assert all_dirs == []  # noqa: F821
+
+
 def test_device_sync_empty_remote(mocker, mock_device, sync_path):
     payload = ("_BELAYR" + repr([b""] * 5) + "\r\n").encode("utf-8")
     mock_device._board.exec = mocker.MagicMock(return_value=payload)

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -1,4 +1,3 @@
-import ast
 import os
 from pathlib import Path, PosixPath
 from unittest.mock import call
@@ -345,4 +344,24 @@ def test_preprocess_src_file_default_generic(tmp_path):
 
 
 def test_generate_dst_dirs():
-    pass
+    dst = "/foo/bar"
+    src = Path("/bloop/bleep")
+    src_dirs = [
+        src / "dir1",
+        src / "dir1" / "dir1_1",
+        src / "dir1" / "dir1_2",
+        src / "dir2",
+        src / "dir2" / "dir2_1",
+        src / "dir2" / "dir2_2",
+    ]
+    dst_dirs = belay.device._generate_dst_dirs(dst, src, src_dirs)
+    assert dst_dirs == [
+        "/foo",
+        "/foo/bar",
+        "/foo/bar/dir1",
+        "/foo/bar/dir1/dir1_1",
+        "/foo/bar/dir1/dir1_2",
+        "/foo/bar/dir2",
+        "/foo/bar/dir2/dir2_1",
+        "/foo/bar/dir2/dir2_2",
+    ]

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -236,3 +236,40 @@ def test_discover_files_dirs_single_file(tmp_path):
     assert src_files == [PosixPath("file1.ext")]
     assert src_dirs == []
     assert dst_files == [PosixPath("/foo/bar/file1.ext")]
+
+
+def test_preprocess_keep_none_root():
+    actual = belay.device._preprocess_keep(None, "/")
+    assert actual == ["/boot.py", "/webrepl_cfg.py"]
+
+
+def test_preprocess_keep_none_nonroot():
+    actual = belay.device._preprocess_keep(None, "/foo")
+    assert actual == []
+
+
+def test_preprocess_keep_list():
+    actual = belay.device._preprocess_keep(["foo"], "/")
+    assert actual == ["/foo"]
+
+
+def test_preprocess_keep_bool_true():
+    actual = belay.device._preprocess_keep(True, "/")
+    assert actual == []
+
+
+def test_preprocess_keep_bool_false():
+    actual = belay.device._preprocess_keep(False, "/")
+    assert actual == []
+
+
+def test_preprocess_ignore():
+    pass
+
+
+def test_preprocess_src_file():
+    pass
+
+
+def test_generate_dst_dirs():
+    pass

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -253,6 +253,11 @@ def test_preprocess_keep_list():
     assert actual == ["/foo"]
 
 
+def test_preprocess_keep_str():
+    actual = belay.device._preprocess_keep("foo", "/")
+    assert actual == ["/foo"]
+
+
 def test_preprocess_keep_bool_true():
     actual = belay.device._preprocess_keep(True, "/")
     assert actual == []
@@ -263,8 +268,19 @@ def test_preprocess_keep_bool_false():
     assert actual == []
 
 
-def test_preprocess_ignore():
-    pass
+def test_preprocess_ignore_none():
+    actual = belay.device._preprocess_ignore(None)
+    assert actual == ["*.pyc", "__pycache__", ".DS_Store", ".pytest_cache"]
+
+
+def test_preprocess_ignore_list():
+    actual = belay.device._preprocess_ignore(["foo", "bar"])
+    assert actual == ["foo", "bar"]
+
+
+def test_preprocess_ignore_str():
+    actual = belay.device._preprocess_ignore("foo")
+    assert actual == ["foo"]
 
 
 def test_preprocess_src_file():

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -182,7 +182,7 @@ def test_device_sync_partial_remote(mocker, mock_device, sync_path):
     )
 
 
-def test_discover_files_dirs_typical(tmp_path):
+def test_discover_files_dirs_dir(tmp_path):
     (tmp_path / "file1.ext").touch()
     (tmp_path / "file2.ext").touch()
     (tmp_path / "folder1").mkdir()
@@ -205,6 +205,32 @@ def test_discover_files_dirs_typical(tmp_path):
     assert dst_files == [
         PosixPath("/foo/bar/file1.ext"),
         PosixPath("/foo/bar/file2.ext"),
+        PosixPath("/foo/bar/folder1/file3.ext"),
+    ]
+
+
+def test_discover_files_dirs_dir_ignore(tmp_path):
+    (tmp_path / "file1.ext").touch()
+    (tmp_path / "file2.pyc").touch()
+    (tmp_path / "folder1").mkdir()
+    (tmp_path / "folder1" / "file3.ext").touch()
+
+    remote_dir = "/foo/bar"
+    src_files, src_dirs, dst_files = belay.device._discover_files_dirs(
+        remote_dir=remote_dir,
+        local_file_or_folder=tmp_path,
+        ignore=["*.pyc"],
+    )
+
+    src_files = [x.relative_to(tmp_path) for x in src_files]
+    src_dirs = [x.relative_to(tmp_path) for x in src_dirs]
+    assert src_files == [
+        PosixPath("file1.ext"),
+        PosixPath("folder1/file3.ext"),
+    ]
+    assert src_dirs == [PosixPath("folder1")]
+    assert dst_files == [
+        PosixPath("/foo/bar/file1.ext"),
         PosixPath("/foo/bar/folder1/file3.ext"),
     ]
 


### PR DESCRIPTION
* [new command] `run` runs a file.
* [new command] `exec` executes a python statement.
* `sync` improvements:
    * New argument `dst`; defaults to `"/"`; folder to sync file into.
    * New argument `ignore`; uses gitignore pattern matching to ignore files during sync.
    * New argument `mpy_cross_binary`; if provided, will compile `.py` files into `.mpy` prior to syncing.
    * Can now sync a single file.
    * Now keeps all untouched files if `keep=True`.
    * Misc bug fixes.