### PR TITLE
Emitter check

### DIFF
--- a/belay/device.py
+++ b/belay/device.py
@@ -645,7 +645,12 @@ class Device:
         # This is so we know what to clean up after done syncing.
         if progress_update:
             progress_update(description="Bootstrapping sync...")
-        self._exec_snippet("sync_begin")
+        if "viper" in self.implementation.emitters:
+            self._exec_snippet("hf_viper", "sync_begin")
+        elif "native" in self.implementation.emitters:
+            self._exec_snippet("hf_native", "sync_begin")
+        else:
+            self._exec_snippet("hf", "sync_begin")
 
         # Remove the keep files from the on-device ``all_files`` set
         # so they don't get deleted.

--- a/belay/device.py
+++ b/belay/device.py
@@ -643,14 +643,23 @@ class Device:
 
         # Create a list of all files and dirs (on-device).
         # This is so we know what to clean up after done syncing.
+        snippets_to_execute = []
+
         if progress_update:
             progress_update(description="Bootstrapping sync...")
         if "viper" in self.implementation.emitters:
-            self._exec_snippet("hf_viper", "sync_begin")
+            snippets_to_execute.append("hf_viper")
         elif "native" in self.implementation.emitters:
-            self._exec_snippet("hf_native", "sync_begin")
+            snippets_to_execute.append("hf_native")
         else:
-            self._exec_snippet("hf", "sync_begin")
+            snippets_to_execute.append("hf")
+
+        if self.implementation.name == "circuitpython":
+            snippets_to_execute.append("ilistdir_circuitpython")
+        else:
+            snippets_to_execute.append("ilistdir_micropython")
+        snippets_to_execute.append("sync_begin")
+        self._exec_snippet(*snippets_to_execute)
 
         # Remove the keep files from the on-device ``all_files`` set
         # so they don't get deleted.

--- a/belay/device.py
+++ b/belay/device.py
@@ -425,7 +425,7 @@ class Implementation:
     name: str
     version: Tuple[int, int, int]
     platform: str
-    emitters: tuple[str]
+    emitters: Tuple[str]
 
 
 class Device:

--- a/belay/snippets/emitter_check.py
+++ b/belay/snippets/emitter_check.py
@@ -1,0 +1,4 @@
+@micropython.native
+def __belay_dec_test(a, b): return a + b
+@micropython.viper
+def __belay_dec_test(a, b): return a + b

--- a/belay/snippets/emitter_check.py
+++ b/belay/snippets/emitter_check.py
@@ -1,4 +1,4 @@
 @micropython.native
-def __belay_dec_test(a, b): return a + b
+def __belay_emitter_test(a, b): return a + b
 @micropython.viper
-def __belay_dec_test(a, b): return a + b
+def __belay_emitter_test(a, b): return a + b

--- a/belay/snippets/hf.py
+++ b/belay/snippets/hf.py
@@ -1,0 +1,16 @@
+def __belay_hf(fn, buf):
+    # inherently is inherently modulo 32-bit arithmetic
+    mod = (1 << 32)
+    h = 0x811c9dc5
+    try:
+        f = open(fn, "rb")
+        while True:
+            n = f.readinto(buf)
+            if n == 0:
+                break
+            for b in buf[:n]:
+                h = ((h ^ b) * 0x01000193) % mod  # todo: investigate fast mm
+        f.close()
+    except OSError:
+        h = 0
+    return h

--- a/belay/snippets/hf_native.py
+++ b/belay/snippets/hf_native.py
@@ -1,0 +1,17 @@
+@micropython.native
+def __belay_hf(fn, buf):
+    # inherently is inherently modulo 32-bit arithmetic
+    mod = (1 << 32)
+    h = 0x811c9dc5
+    try:
+        f = open(fn, "rb")
+        while True:
+            n = f.readinto(buf)
+            if n == 0:
+                break
+            for b in buf[:n]:
+                h = ((h ^ b) * 0x01000193) % mod  # todo: investigate fast mm
+        f.close()
+    except OSError:
+        h = 0
+    return h

--- a/belay/snippets/hf_viper.py
+++ b/belay/snippets/hf_viper.py
@@ -1,0 +1,21 @@
+@micropython.native
+def __belay_hf(fn, buf):
+    # inherently is inherently modulo 32-bit arithmetic
+    @micropython.viper
+    def xor_mm(data, state: uint, prime: uint) -> uint:
+        for b in data:
+            state = uint((state ^ uint(b)) * prime)
+        return state
+
+    h = 0x811c9dc5
+    try:
+        f = open(fn, "rb")
+        while True:
+            n = f.readinto(buf)
+            if n == 0:
+                break
+            h = xor_mm(buf[:n], h, 0x01000193)
+        f.close()
+    except OSError:
+        h = 0
+    return h

--- a/belay/snippets/ilistdir_circuitpython.py
+++ b/belay/snippets/ilistdir_circuitpython.py
@@ -2,4 +2,3 @@ def __belay_ilistdir(x):
     for name in os.listdir(x):
         stat = os.stat(x + "/" + name)  # noqa: PL116
         yield (name, stat[0], stat[1])
-

--- a/belay/snippets/ilistdir_circuitpython.py
+++ b/belay/snippets/ilistdir_circuitpython.py
@@ -1,0 +1,5 @@
+def __belay_ilistdir(x):
+    for name in os.listdir(x):
+        stat = os.stat(x + "/" + name)  # noqa: PL116
+        yield (name, stat[0], stat[1])
+

--- a/belay/snippets/ilistdir_micropython.py
+++ b/belay/snippets/ilistdir_micropython.py
@@ -1,1 +1,1 @@
-__belay_ilistdir = os.listdir
+__belay_ilistdir = os.ilistdir

--- a/belay/snippets/ilistdir_micropython.py
+++ b/belay/snippets/ilistdir_micropython.py
@@ -1,0 +1,1 @@
+__belay_ilistdir = os.listdir

--- a/belay/snippets/startup.py
+++ b/belay/snippets/startup.py
@@ -1,4 +1,4 @@
-import sys
+import os, sys
 def __belay(name):
     def inner(f):
         def func_wrapper(*args, **kwargs):

--- a/belay/snippets/sync_begin.py
+++ b/belay/snippets/sync_begin.py
@@ -1,11 +1,4 @@
 # Creates and populates two set[str]: all_files, all_dirs
-try:
-    ilistdir = os.ilistdir
-except AttributeError:
-    def ilistdir(x):
-        for name in os.listdir(x):
-            stat = os.stat(x + "/" + name)  # noqa: PL116
-            yield (name, stat[0], stat[1])
 def __belay_hfs(fns):
     buf = memoryview(bytearray(4096))
     print("_BELAYR" + repr([__belay_hf(fn, buf) for fn in fns]))
@@ -26,7 +19,7 @@ def __belay_fs(path="/", check=True):
             os.stat(path)
         except OSError:
             return
-    for elem in ilistdir(path):
+    for elem in __belay_ilistdir(path):
         full_name = path + elem[0]
         if elem[1] & 0x4000:  # is_dir
             all_dirs.append(full_name)

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -13,7 +13,7 @@ def uint(x):
     return x % (1 << 32)
 
 
-def ilistdir(x):
+def __belay_ilistdir(x):
     for name in os.listdir(x):
         stat = os.stat(x + "/" + name)  # noqa: PL116
         yield (name, stat.st_mode, stat.st_ino)

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -50,18 +50,44 @@ def sync_path(tmp_path):
     return tmp_path
 
 
-@pytest.fixture
-def sync_begin():
-    snippet = belay.device._read_snippet("sync_begin")
+def _patch_micropython_code(snippet):
     # Patch out micropython stuff
     lines = snippet.split("\n")
     lines = [x for x in lines if "micropython" not in x]
     snippet = "\n".join(lines)
     snippet = snippet.replace("os.ilistdir", "ilistdir")
+    return snippet
+
+
+@pytest.fixture
+def sync_begin():
+    snippet = belay.device._read_snippet("sync_begin")
+    snippet = _patch_micropython_code(snippet)
     exec(snippet, globals())
 
 
-def test_sync_local_belay_hf(sync_begin, tmp_path):
+@pytest.fixture
+def hf():
+    snippet = belay.device._read_snippet("hf")
+    snippet = _patch_micropython_code(snippet)
+    exec(snippet, globals())
+
+
+@pytest.fixture
+def hf_native():
+    snippet = belay.device._read_snippet("hf_native")
+    snippet = _patch_micropython_code(snippet)
+    exec(snippet, globals())
+
+
+@pytest.fixture
+def hf_viper():
+    snippet = belay.device._read_snippet("hf_viper")
+    snippet = _patch_micropython_code(snippet)
+    exec(snippet, globals())
+
+
+def test_sync_local_belay_hf(tmp_path):
     """Test local FNV-1a hash implementation.
 
     Test vector from: http://www.isthe.com/chongo/src/fnv/test_fnv.c
@@ -72,8 +98,26 @@ def test_sync_local_belay_hf(sync_begin, tmp_path):
     assert actual == 0xBF9CF968
 
 
-def test_sync_device_belay_hf(sync_begin, tmp_path):
+def test_sync_device_belay_hf(hf, tmp_path):
     """Test on-device FNV-1a hash implementation."""
+    f = tmp_path / "test_file"
+    f.write_text("foobar")
+    buf = memoryview(bytearray(4096))
+    actual = __belay_hf(str(f), buf)  # noqa: F821
+    assert actual == 0xBF9CF968
+
+
+def test_sync_device_belay_hf_native(hf_native, tmp_path):
+    """Test on-device FNV-1a native hash implementation."""
+    f = tmp_path / "test_file"
+    f.write_text("foobar")
+    buf = memoryview(bytearray(4096))
+    actual = __belay_hf(str(f), buf)  # noqa: F821
+    assert actual == 0xBF9CF968
+
+
+def test_sync_device_belay_hf_viper(hf_viper, tmp_path):
+    """Test on-device FNV-1a viper hash implementation."""
     f = tmp_path / "test_file"
     f.write_text("foobar")
     buf = memoryview(bytearray(4096))


### PR DESCRIPTION
* Adds `device.implementation.emitters`
* Fixes `sync` on devices without native/viper emitters available.