### PR TITLE
Fix multiline string inspect

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -21,6 +21,7 @@ exclude =
     .venv
     examples/
     belay/snippets/
+    tests/test_inspect.py
 
 extend-immutable-calls =
     Argument

--- a/belay/inspect.py
+++ b/belay/inspect.py
@@ -1,5 +1,16 @@
 import inspect
 import re
+from io import StringIO
+from tokenize import (
+    COMMENT,
+    DEDENT,
+    INDENT,
+    NEWLINE,
+    OP,
+    STRING,
+    generate_tokens,
+    untokenize,
+)
 from typing import Tuple
 
 _pat_no_decorators = re.compile(
@@ -7,10 +18,46 @@ _pat_no_decorators = re.compile(
 )
 
 
-def getsource(f) -> Tuple[str, int, str]:
-    """Get source code data without decorators.
+class _NoAction(Exception):
+    pass
 
-    Trims leading whitespace and removes decorators.
+
+def _dedent_tokenizer(code):
+    indent_to_remove = ""
+    for (
+        token_type,
+        string,
+        (start_line, start_col),
+        (end_line, end_col),  # noqa: B007
+        _,
+    ) in generate_tokens(StringIO(code).readline):
+        print(f"{token_type=} {string=} {start_line=} {end_line=}")
+        if start_line == 1 and start_col == 0:
+            # First Token
+            if token_type != INDENT:
+                # No action to perform
+                raise _NoAction
+            indent_to_remove = string
+        if start_col == 0:
+            if token_type == INDENT:
+                if not string.startswith(indent_to_remove):
+                    raise IndentationError
+                string = string[len(indent_to_remove) :]
+        yield token_type, string
+
+
+def _dedent(code):
+    try:
+        return untokenize(_dedent_tokenizer(code))
+    except _NoAction:
+        return code
+
+
+def getsource(f) -> Tuple[str, int, str]:
+    """Get source code with mild post processing.
+
+    * strips leading decorators.
+    * Trims leading whitespace indent.
 
     Parameters
     ----------
@@ -20,7 +67,7 @@ def getsource(f) -> Tuple[str, int, str]:
     Returns
     -------
     src_code: str
-        Source code.
+        Source code. Always ends in a newline.
     src_lineno: int
         Line number of code begin.
     src_file: str
@@ -39,12 +86,9 @@ def getsource(f) -> Tuple[str, int, str]:
 
     lines = lines[offset:]
 
-    # Trim leading whitespace
-    # TODO: This breaks multiline things
-    n_leading_whitespace = len(lines[0]) - len(lines[0].lstrip())
-    lines = [line[n_leading_whitespace:] for line in lines]
-
     src_code = "".join(lines)
     src_lineno += offset
+
+    src_code = _dedent(src_code)
 
     return src_code, src_lineno, src_file

--- a/belay/inspect.py
+++ b/belay/inspect.py
@@ -40,6 +40,7 @@ def getsource(f) -> Tuple[str, int, str]:
     lines = lines[offset:]
 
     # Trim leading whitespace
+    # TODO: This breaks multiline things
     n_leading_whitespace = len(lines[0]) - len(lines[0].lstrip())
     lines = [line[n_leading_whitespace:] for line in lines]
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -84,3 +84,41 @@ def test_getsource_decorated_6(foo):
     assert code == "def foo_decorated_6(arg1, arg2):\n    return arg1 + arg2\n"
     assert lineno == 51
     assert file == foo.__file__
+
+
+def test_getsource_decorated_7(foo):
+    """Double decorated."""
+    code, lineno, file = belay.inspect.getsource(foo.foo_decorated_7)
+    assert (
+        code
+        == 'def foo_decorated_7(arg1, arg2):\n    return """This\n    is\na\n  multiline\n             string.\n"""\n'
+    )
+    assert lineno == 56
+    assert file == foo.__file__
+
+
+def test_getsource_nested():
+    def foo():
+        bar = 5
+        return 7
+
+    code, lineno, file = belay.inspect.getsource(foo)
+    assert code == "def foo():\n    bar = 5\n    return 7\n"
+    assert file == __file__
+
+
+def test_getsource_nested_multiline_string():
+    def foo(arg1, arg2):
+        return """This
+    is
+a
+  multiline
+             string.
+"""
+
+    code, lineno, file = belay.inspect.getsource(foo)
+    assert (
+        code
+        == 'def foo(arg1, arg2):\n    return """This\n    is\na\n  multiline\n             string.\n"""\n'
+    )
+    assert file == __file__

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,3 +1,10 @@
+"""Tests extensions to the builtin inspect module.
+
+Note: ``untokenize`` doesn't properly preserve inter-token spacing, so this test vector
+may need to change while still remaining valid.
+"""
+
+
 from importlib.machinery import SourceFileLoader
 
 import pytest
@@ -73,7 +80,7 @@ def test_getsource_decorated_4(foo):
 def test_getsource_decorated_5(foo):
     """Removes leading indent."""
     code, lineno, file = belay.inspect.getsource(foo.foo_decorated_5)
-    assert code == "def foo_decorated_5(arg1, arg2):\n    return arg1 + arg2\n"
+    assert code == "def foo_decorated_5 (arg1 ,arg2 ):\n    return arg1 +arg2 \n"
     assert lineno == 45
     assert file == foo.__file__
 
@@ -103,13 +110,15 @@ def test_getsource_nested():
         return 7
 
     code, lineno, file = belay.inspect.getsource(foo)
-    assert code == "def foo():\n    bar = 5\n    return 7\n"
+    assert code == "def foo ():\n    bar =5 \n    return 7 \n"
     assert file == __file__
 
 
 def test_getsource_nested_multiline_string():
-    def foo(arg1, arg2):
-        return """This
+    for _ in range(1):
+
+        def foo(arg1, arg2):
+            return """This
     is
 a
   multiline
@@ -119,6 +128,6 @@ a
     code, lineno, file = belay.inspect.getsource(foo)
     assert (
         code
-        == 'def foo(arg1, arg2):\n    return """This\n    is\na\n  multiline\n             string.\n"""\n'
+        == 'def foo (arg1 ,arg2 ):\n    return """This\n    is\na\n  multiline\n             string.\n"""\n'
     )
     assert file == __file__

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -131,3 +131,25 @@ a
         == 'def foo (arg1 ,arg2 ):\n    return """This\n    is\na\n  multiline\n             string.\n"""\n'
     )
     assert file == __file__
+
+
+def test_getsource_nested_multiline_string():
+    # fmt: off
+    def bar(a, b):
+        return a * b
+
+    for _ in range(1):
+
+        def foo(arg1, arg2):
+            return bar(
+arg1,
+    arg2
+)
+
+    # fmt: on
+    code, lineno, file = belay.inspect.getsource(foo)
+    assert (
+        code
+        == "def foo (arg1 ,arg2 ):\n    return bar (\n    arg1 ,\n    arg2 \n    )\n"
+    )
+    assert file == __file__

--- a/tests/test_inspect/foo.py
+++ b/tests/test_inspect/foo.py
@@ -50,3 +50,13 @@ if True:
 @decorator
 def foo_decorated_6(arg1, arg2):
     return arg1 + arg2
+
+
+@decorator
+def foo_decorated_7(arg1, arg2):
+    return """This
+    is
+a
+  multiline
+             string.
+"""


### PR DESCRIPTION
Previously, Belay would corrupt a multiline string when obtaining source code.