### PR TITLE
change all references to .belay-lib -> .belay/dependencies/default

### DIFF
--- a/belay/cli/install.py
+++ b/belay/cli/install.py
@@ -31,7 +31,7 @@ def install(
 
     sync(
         port=port,
-        folder=Path(".belay-lib"),
+        folder=Path(".belay/dependencies/default"),
         dst="/lib",
         password=password,
         keep=None,

--- a/belay/cli/new_template/pyproject.toml
+++ b/belay/cli/new_template/pyproject.toml
@@ -4,4 +4,4 @@ name = "packagename"
 [tool.belay.dependencies]
 
 [tool.pytest.ini_options]
-pythonpath = ".belay-lib"
+pythonpath = ".belay/dependencies/default"

--- a/belay/packagemanager.py
+++ b/belay/packagemanager.py
@@ -62,7 +62,7 @@ def _get_text(url: Union[str, Path]):
 def download_dependencies(
     dependencies: Dict[str, Union[str, Dict]],
     packages: Optional[List[str]] = None,
-    local_dir: Union[str, Path] = ".belay-lib",
+    local_dir: Union[str, Path] = ".belay/dependencies/default",
     console: Optional[Console] = None,
 ):
     """Download dependencies.
@@ -129,7 +129,7 @@ def download_dependencies(
 
 def clean_local(
     dependencies: Union[Set[str], List[str]],
-    local_dir: Union[str, Path] = ".belay-lib",
+    local_dir: Union[str, Path] = ".belay/dependencies/default",
 ):
     """Delete downloaded dependencies if they are no longer referenced."""
     local_dir = Path(local_dir)

--- a/docs/source/Package Manager.rst
+++ b/docs/source/Package Manager.rst
@@ -6,10 +6,10 @@ In a nutshell, the Belay Package Manager does the following:
 
 1. Reads settings from ``pyproject.toml``. Dependencies are defined by URL's where they can be fetched.
    Commonly these are files hosted on github.
-2. Downloads dependencies to the ``.belay-lib`` folder. This folder should be committed to your
+2. Downloads dependencies to the ``.belay/dependencies/default`` folder. This folder should be committed to your
    project's git repository. This allows for repeatable deployment, even if a remote dependency
    goes missing or changes it's API.
-3. Syncs the contents of ``.belay-lib`` to the on-device ``/lib`` folder. This folder is included
+3. Syncs the contents of ``.belay/dependencies/default`` to the on-device ``/lib`` folder. This folder is included
    in the on-device ``PATH``.
 4. Syncs the contents of your project directory.
 
@@ -27,7 +27,7 @@ A typical project will look like:
    some_dependency = "https://github.com/BrianPugh/some-dependency/blob/main/some_dependency.py"
 
    [tool.pytest.ini_options]
-   pythonpath = ".belay-lib"
+   pythonpath = ".belay/dependencies/default"
 
 Belay assumes your project contains a python-package with the same name as ``tool.belay.name`` located in the root of your project.
 
@@ -53,8 +53,8 @@ Update
 ``belay update`` iterates over and downloads the dependencies defined
 in ``tool.belay.dependencies`` of ``pyproject.toml``.
 This command should be ran from the root of your project, and is ran when new upstream library changes want to be pulled.
-The downloaded dependencies are stored in ``.belay-lib/`` of the current working directory.
-``.belay-lib/`` should be committed to your git repo and can be thought of as a dependency lock file.
+The downloaded dependencies are stored in ``.belay/dependencies/default/`` of the current working directory.
+``.belay/dependencies/default/`` should be committed to your git repo and can be thought of as a dependency lock file.
 
 This decision is made because:
 

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -22,7 +22,7 @@ def test_install_basic(mocker):
     assert mock_sync.call_args_list == [
         mocker.call(
             port="/dev/ttyUSB0",
-            folder=Path(".belay-lib"),
+            folder=Path(".belay/dependencies/default"),
             dst="/lib",
             password="password",
             keep=None,


### PR DESCRIPTION
# Breaking Change
Change the `.belay-lib/` folder (for package managed dependencies) to `.belay/dependencies/default`. This in preparation for supporting dependency groups. Also prepares for future belay project files.