### PR TITLE
SetupExecuter autoinit

### DIFF
--- a/docs/source/Quick Start.rst
+++ b/docs/source/Quick Start.rst
@@ -175,3 +175,21 @@ Methods marked with ``@Device.task`` are similar to ``@staticmethod`` in that
 they do **not** contain ``self`` in the method signature.
 To the device, each marked method is equivalent to an independent function.
 Methods can be marked with ``@Device.setup`` or ``@Device.thread`` for their respective functionality.
+
+For methods decorated with ``@Device.setup``, the flag ``autoinit=True`` can be set to automatically
+call the method at the end of object creation.
+The decorated method must have no parameters, otherwise a ``ValueError`` will be raised.
+
+.. code-block:: python
+
+   from belay import Device
+
+
+   class MyDevice(Device):
+       @Device.setup(autoinit=True)
+       def setup():
+           foo = 42
+
+
+   device = MyDevice("/dev/ttyUSB0")
+   # Do NOT explicitly call ``device.setup()``, it has already been invoked.

--- a/examples/08_device_subclassing/main.py
+++ b/examples/08_device_subclassing/main.py
@@ -10,14 +10,22 @@ args = parser.parse_args()
 
 class MyDevice(Device):
     # NOTE: ``Device`` is capatalized here!
+    @Device.setup(
+        autoinit=True
+    )  # ``autoinit=True`` means this method will automatically be called during object creation.
+    def setup():
+        # Code here is executed on-device in a global context.
+        led_pin = Pin(25, Pin.OUT)
+        sensor_temp = ADC(
+            4
+        )  # ADC4 is attached to an internal temperature sensor on the Pi Pico
+
     @Device.task
     def set_led(state):
-        Pin(25, Pin.OUT).value(state)
+        led_pin.value(state)
 
     @Device.task
     def read_temperature():
-        # ADC4 is attached to an internal temperature sensor
-        sensor_temp = ADC(4)
         reading = sensor_temp.read_u16()
         reading *= 3.3 / 65535  # Convert reading to a voltage.
         temperature = 27 - (reading - 0.706) / 0.001721  # Convert voltage to Celsius

--- a/poetry.lock
+++ b/poetry.lock
@@ -699,6 +699,17 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.1.0"
+description = "pytest plugin to abort hanging tests"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pytest = ">=5.0.0"
+
+[[package]]
 name = "pytz"
 version = "2022.6"
 description = "World timezone definitions, modern and historical"
@@ -1058,7 +1069,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "3d34439f9bc523cdfb0bad15d4a489beb0b54a54b793749bdf29c6b78c9d5730"
+content-hash = "5071cfab3e1c6f604ac6c96680f9cc343b60bc17ff3c7297d9eddfe155e967e1"
 
 [metadata.files]
 alabaster = [
@@ -1431,6 +1442,10 @@ pytest-cov = [
 pytest-mock = [
     {file = "pytest-mock-3.10.0.tar.gz", hash = "sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f"},
     {file = "pytest_mock-3.10.0-py3-none-any.whl", hash = "sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b"},
+]
+pytest-timeout = [
+    {file = "pytest-timeout-2.1.0.tar.gz", hash = "sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9"},
+    {file = "pytest_timeout-2.1.0-py3-none-any.whl", hash = "sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6"},
 ]
 pytz = [
     {file = "pytz-2022.6-py2.py3-none-any.whl", hash = "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ pre_commit = "^2.16.0"
 pytest = "^7.2.0"
 pytest-cov = "^3.0.0"
 pytest-mock = "^3.7.0"
+pytest-timeout = "^2.1.0"
 
 [tool.poetry.group.debug]
 optional = true
@@ -93,5 +94,5 @@ exclude_dirs = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--import-mode=importlib"
+addopts = "--import-mode=importlib --timeout=120"
 norecursedirs = "integration"

--- a/tests/integration/test_classes.py
+++ b/tests/integration/test_classes.py
@@ -1,10 +1,10 @@
 import pytest
 
-from belay import Device
+from belay import Device, PyboardException
 
 
 def test_classes_basic(emulate_command):
-    class MyDevice(Device):
+    class MyDevice(Device, skip=True):
         @Device.setup
         def setup():
             foo = 10  # noqa: F841
@@ -19,6 +19,9 @@ def test_classes_basic(emulate_command):
             return val * bar  # noqa: F821
 
     with MyDevice(emulate_command) as device:
+        with pytest.raises(PyboardException):
+            device("foo")  # it shouldn't exist yet
+
         device.setup()
 
         assert 10 == device.get_times_foo(1)
@@ -26,3 +29,43 @@ def test_classes_basic(emulate_command):
 
         assert 42 == device.get_times_bar(1)
         assert 84 == device.get_times_bar(2)
+
+
+def test_classes_setup_autoinit(emulate_command):
+    class MyDevice(Device, skip=True):
+        @Device.setup(autoinit=True)
+        def setup1():
+            foo = 10  # noqa: F841
+            bar = 42  # noqa: F841
+
+        @Device.setup(autoinit=True)
+        def setup2():
+            foo = 100  # noqa: F841
+
+    with MyDevice(emulate_command) as device:
+        # These 2 checks confirm ``setup2`` ran after ``setup1``.
+        assert device("foo") == 100
+        assert device("bar") == 42
+
+
+def test_classes_setup_autoinit_arguments(emulate_command):
+    with pytest.raises(ValueError):
+
+        class MyDevice1(Device, skip=True):
+            @Device.setup(autoinit=True)
+            def setup(foo):
+                pass
+
+    with pytest.raises(ValueError):
+
+        class MyDevice2(Device, skip=True):
+            @Device.setup(autoinit=True)
+            def setup(foo=1):
+                pass
+
+    with pytest.raises(ValueError):
+
+        class MyDevice3(Device, skip=True):
+            @Device.setup(autoinit=True)
+            def setup(*, foo=1):
+                pass


### PR DESCRIPTION
If decorated methods are supplied the `autoinit=True` flag, then they will automatically be invoked upon object initialization. E.g.

```
class MyDevice(Device):
    @Device.setup(autoinit=True)
    def setup():
        foo = 42

my_device = MyDevice()  # ``MyDevice.setup`` will automatically be invoked.
```

If the decorated method takes in arguments and `autoinit=True`, then a `ValueError` will be raised. `autoinit` methods will be executed in order-defined.


TODO prior to merge: update documentation and examples.