### PR TITLE
Teardown Executer

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,7 +99,7 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          python -m pytest --cov=belay --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml tests tests/integration
+          python -m pytest --cov=belay --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml --timeout=120 tests tests/integration
           coverage report
 
       - name: Upload coverage to Codecov

--- a/belay/device.py
+++ b/belay/device.py
@@ -17,7 +17,13 @@ from serial import SerialException
 
 from ._minify import minify as minify_code
 from .exceptions import ConnectionLost, MaxHistoryLengthError
-from .executers import Executer, SetupExecuter, TaskExecuter, ThreadExecuter
+from .executers import (
+    Executer,
+    SetupExecuter,
+    TaskExecuter,
+    TeardownExecuter,
+    ThreadExecuter,
+)
 from .hash import fnv1a
 from .helpers import read_snippet, wraps_partial
 from .inspect import isexpression
@@ -159,6 +165,10 @@ def _generate_dst_dirs(dst, src, src_dirs) -> list:
     return dst_dirs
 
 
+def _sort_executers(executers):
+    return sorted(executers, key=lambda x: x.__wrapped__.__belay__.id)
+
+
 @dataclass
 class Implementation:
     """Implementation dataclass detailing the device.
@@ -232,6 +242,7 @@ class Device(Registry):
         self._board_kwargs = signature(Pyboard).bind(*args, **kwargs).arguments
         self.attempts = attempts
         self._cmd_history = []
+        self._teardown_executers = []
 
         self._connect_to_board(**self._board_kwargs)
 
@@ -265,18 +276,19 @@ class Device(Registry):
             decorator = getattr(self, metadata.executer.__registry__.name)
             executer = decorator(method, **metadata.kwargs)
 
-            if isinstance(decorator, SetupExecuter):
-                if metadata.autoinit:
-                    autoinit_executers.append(executer)
+            if metadata.autoinit:
+                autoinit_executers.append(executer)
+            if isinstance(decorator, TeardownExecuter):
+                self._teardown_executers.append(executer)
+
             setattr(
                 self,
                 name,
                 executer,
             )
 
-        autoinit_executers = sorted(
-            autoinit_executers, key=lambda x: x.__wrapped__.__belay__.id
-        )
+        self._teardown_executers = _sort_executers(self._teardown_executers)
+        autoinit_executers = _sort_executers(autoinit_executers)
         for executer in autoinit_executers:
             executer()
 
@@ -547,6 +559,9 @@ class Device(Registry):
 
     def close(self) -> None:
         """Close the connection to device."""
+        for executer in self._teardown_executers:
+            executer()
+
         return self._board.close()
 
     def reconnect(self, attempts: Optional[int] = None) -> None:
@@ -619,6 +634,42 @@ class Device(Registry):
         return f
 
     @staticmethod
+    def teardown(f=None, **kwargs) -> Callable:
+        """teardown(f, *, minify=True, register=True, record=True)
+
+        Decorator that executes function's body in a global-context on-device
+        when ``device.close()`` is called.
+
+        Function arguments are also set in the global context.
+
+        Can either be used as a staticmethod ``@Device.teardown`` for marking methods in a subclass of ``Device``, or as a standard method ``@device.teardown`` for marking functions to a specific ``Device`` instance.
+
+        Parameters
+        ----------
+        f: Callable
+            Function to decorate. Can only accept and return python literals.
+        minify: bool
+            Minify ``cmd`` code prior to sending.
+            Defaults to ``True``.
+        register: bool
+            Assign an attribute to ``self.teardown`` with same name as ``f``.
+            Defaults to ``True``.
+        record: bool
+            Each invocation of the executer is recorded for playback upon reconnect.
+            Defaults to ``True``.
+        """  # noqa: D400
+        if f is None:
+            return wraps_partial(Device.setup, **kwargs)  # type: ignore[reportGeneralTypeIssues]
+
+        if signature(f).parameters:
+            raise ValueError(
+                f'Method {f} decorated with "@Device.teardown" must have no arguments.'
+            )
+
+        f.__belay__ = MethodMetadata(executer=TeardownExecuter, kwargs=kwargs)
+        return f
+
+    @staticmethod
     def task(f=None, **kwargs) -> Callable:
         """task(f, *, minify=True, register=True, record=False)
 
@@ -643,6 +694,7 @@ class Device(Registry):
         """  # noqa: D400
         if f is None:
             return wraps_partial(Device.task, **kwargs)  # type: ignore[reportGeneralTypeIssues]
+
         f.__belay__ = MethodMetadata(executer=TaskExecuter, kwargs=kwargs)
         return f
 

--- a/belay/device.py
+++ b/belay/device.py
@@ -253,7 +253,13 @@ class Device(Registry):
         self._connect_to_board(**self._board_kwargs)
 
         for executer_name, executer_cls in Executer.items():
-            setattr(self, executer_name, executer_cls(self))
+            executer = executer_cls(self)
+            setattr(
+                self, executer_name, executer
+            )  # Public interface; might get stomped
+            setattr(
+                self, "_belay_" + executer_name, executer
+            )  # Private interface; will always be there
 
         self._exec_snippet("startup")
 
@@ -563,7 +569,7 @@ class Device(Registry):
     def close(self) -> None:
         """Close the connection to device."""
         # Invoke all teardown executers prior to closing out connection.
-        for executer in _sort_executers(self.teardown._belay_executers):
+        for executer in _sort_executers(self._belay_teardown._belay_executers):
             executer()
 
         return self._board.close()

--- a/belay/executers.py
+++ b/belay/executers.py
@@ -37,7 +37,7 @@ class Executer(Registry, suffix="Executer"):
         raise NotImplementedError
 
 
-class SetupExecuter(Executer):
+class _GlobalExecuter(Executer, skip=True):
     def __call__(
         self,
         f: Optional[BelayCallable] = None,
@@ -46,11 +46,12 @@ class SetupExecuter(Executer):
         register: bool = True,
         record: bool = True,
     ):
-        """See ``Device.setup``."""
         if f is None:
             return wraps_partial(self, minify=minify, register=register, record=record)
         if inspect.isgeneratorfunction(f):
-            raise ValueError("@Device.setup does not support generators.")
+            raise ValueError(
+                f"@Device.{type(self).__registry__.name} does not support generators."
+            )
         name = f.__name__
         src_code, src_lineno, src_file = getsource(f, strip_signature=True)
         if minify:
@@ -76,6 +77,10 @@ class SetupExecuter(Executer):
             setattr(self, name, executer)
 
         return executer
+
+
+class SetupExecuter(_GlobalExecuter):
+    pass
 
 
 class TaskExecuter(Executer):

--- a/belay/executers.py
+++ b/belay/executers.py
@@ -14,8 +14,9 @@ from .typing import BelayCallable
 
 class Executer(Registry, suffix="Executer"):
     def __init__(self, device):
-        # To avoid Executer.__setattr__ raising an error
+        # Use object.__setattr__ to avoid Executer.__setattr__ raising an error
         object.__setattr__(self, "_belay_device", device)
+        object.__setattr__(self, "_belay_executers", [])
 
     def __setattr__(self, name: str, value: BelayCallable):
         if (
@@ -75,6 +76,7 @@ class _GlobalExecuter(Executer, skip=True):
 
         if register:
             setattr(self, name, executer)
+        self._belay_executers.append(executer)
 
         return executer
 
@@ -147,6 +149,7 @@ class TaskExecuter(Executer):
 
         if register:
             setattr(self, name, executer)
+        self._belay_executers.append(executer)
 
         return executer
 
@@ -182,5 +185,6 @@ class ThreadExecuter(Executer):
 
         if register:
             setattr(self, name, executer)
+        self._belay_executers.append(executer)
 
         return executer

--- a/belay/executers.py
+++ b/belay/executers.py
@@ -83,6 +83,10 @@ class SetupExecuter(_GlobalExecuter):
     pass
 
 
+class TeardownExecuter(_GlobalExecuter):
+    pass
+
+
 class TaskExecuter(Executer):
     def __call__(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,5 +94,5 @@ exclude_dirs = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--import-mode=importlib --timeout=120"
+addopts = "--import-mode=importlib"
 norecursedirs = "integration"

--- a/tests/integration/test_classes.py
+++ b/tests/integration/test_classes.py
@@ -73,7 +73,36 @@ def test_classes_setup_autoinit_arguments(emulate_command):
                 pass
 
 
-def test_classes_teardown(emulate_command, mocker):
+def test_classes_teardown(emulate_command):
+    """Simply tests as its called and no uncaught exceptions occur."""
+
+    class MyDevice(Device, skip=True):
+        @Device.teardown
+        def teardown():
+            pass
+
+    with MyDevice(emulate_command) as device:
+        device.teardown()  # Testing that it can be directly called
+
+
+def test_classes_teardown_mocked(emulate_command, mocker):
+    """Tests if the teardown functions are executed on close."""
+
+    class MyDevice(Device, skip=True):
+        @Device.teardown
+        def teardown():
+            pass
+
+    device = MyDevice(emulate_command)
+    mock_teardown = mocker.MagicMock()
+    device._belay_teardown._belay_executers[0] = mock_teardown
+    device.close()
+    mock_teardown.assert_called_once()
+
+
+def test_classes_teardown_context_manager_mocked(emulate_command, mocker):
+    """Tests if the teardown functions are executed on close."""
+
     class MyDevice(Device, skip=True):
         @Device.teardown
         def teardown():

--- a/tests/integration/test_classes.py
+++ b/tests/integration/test_classes.py
@@ -1,3 +1,5 @@
+from inspect import isfunction
+
 import pytest
 
 from belay import Device, PyboardException
@@ -69,3 +71,20 @@ def test_classes_setup_autoinit_arguments(emulate_command):
             @Device.setup(autoinit=True)
             def setup(*, foo=1):
                 pass
+
+
+def test_classes_teardown(emulate_command, mocker):
+    class MyDevice(Device, skip=True):
+        @Device.teardown
+        def teardown():
+            pass
+
+    with MyDevice(emulate_command) as device:
+        assert isfunction(device.teardown)
+        assert device.teardown != device._belay_teardown
+        assert len(device._belay_teardown._belay_executers) == 1
+
+        mock_teardown = mocker.MagicMock()
+        device._belay_teardown._belay_executers[0] = mock_teardown
+
+    mock_teardown.assert_called_once()

--- a/tests/integration/test_function_decorators.py
+++ b/tests/integration/test_function_decorators.py
@@ -63,3 +63,17 @@ def test_task_generators_communicate(emulated_device):
     with pytest.raises(StopIteration):
         generator.send(50)
     assert [5, 25] == actual
+
+
+def test_teardown(emulated_device, mocker):
+    @emulated_device.teardown
+    def foo():
+        pass
+
+    mock_teardown = mocker.MagicMock()
+    assert len(emulated_device._belay_teardown._belay_executers) == 1
+    emulated_device._belay_teardown._belay_executers[0] = mock_teardown
+
+    emulated_device.close()
+
+    mock_teardown.assert_called_once()


### PR DESCRIPTION
Adds a new executer, TeardownExecuter, that executes code in a global context right before connection to the device is terminated.