### PR TITLE
Belay run pseudo-venv

### DIFF
--- a/belay/__main__.py
+++ b/belay/__main__.py
@@ -1,3 +1,3 @@
-from .cli.main import app
+from .cli.main import run_app
 
-app(prog_name="belay")
+run_app(prog_name="belay")

--- a/belay/cli/main.py
+++ b/belay/cli/main.py
@@ -6,9 +6,7 @@ from typing import List
 
 import typer
 
-from belay import Device
 from belay.cli.clean import clean
-from belay.cli.common import help_password, help_port
 from belay.cli.exec import exec
 from belay.cli.identify import identify
 from belay.cli.info import info

--- a/belay/cli/main.py
+++ b/belay/cli/main.py
@@ -36,7 +36,11 @@ def run_exec(command: List[str]):
     virtual_env = os.environ.copy()
     # Add all dependency groups to the micropython path.
     virtual_env["MICROPYPATH"] = os.pathsep.join(str(g.folder) for g in groups)
-    subprocess.check_output(command, env=virtual_env)  # nosec
+    subprocess.run(  # nosec
+        command,
+        env=virtual_env,
+        check=True,
+    )
 
 
 def run_app(*args, **kwargs):

--- a/belay/cli/main.py
+++ b/belay/cli/main.py
@@ -54,7 +54,6 @@ def _get(indexable, index, default=None):
 def run_app(*args, **kwargs):
     """Add CLI hacks that are not Typer-friendly here."""
     command = _get(sys.argv, 1)
-    exec_path = _get(sys.argv, 2)
 
     try:
         exec_path = shutil.which(sys.argv[2])

--- a/belay/cli/main.py
+++ b/belay/cli/main.py
@@ -1,3 +1,8 @@
+import os
+import subprocess  # nosec
+import sys
+from typing import List
+
 import typer
 
 from belay import Device
@@ -11,6 +16,7 @@ from belay.cli.new import new
 from belay.cli.run import run
 from belay.cli.sync import sync
 from belay.cli.update import update
+from belay.project import load_groups
 
 app = typer.Typer()
 app.command()(clean)
@@ -22,3 +28,27 @@ app.command()(new)
 app.command()(run)
 app.command()(sync)
 app.command()(update)
+
+
+def run_exec(command: List[str]):
+    """Pseudo-virtual-environment."""
+    groups = load_groups()
+    virtual_env = os.environ.copy()
+    # Add all dependency groups to the micropython path.
+    virtual_env["MICROPYPATH"] = os.pathsep.join(str(g.folder) for g in groups)
+    subprocess.check_output(command, env=virtual_env)  # nosec
+
+
+def run_app(*args, **kwargs):
+    """Add CLI hacks that are not Typer-friendly here."""
+    exec_identifier = "exec:"
+    if sys.argv[1] == "run" and sys.argv[2].startswith(exec_identifier):
+        # See docstring in belay.cli.run.run
+        command = sys.argv[2:].copy()
+        command[0] = command[0][len(exec_identifier) :]
+        if not command[0]:
+            command = command[1:]
+        run_exec(command)
+    else:
+        # Common-case; use Typer functionality.
+        app(*args, **kwargs)

--- a/belay/cli/run.py
+++ b/belay/cli/run.py
@@ -11,7 +11,14 @@ def run(
     file: Path = Argument(..., help="File to run on-device."),
     password: str = Option("", help=help_password),
 ):
-    """Run file on-device."""
+    """Run file on-device.
+
+    If the first argument, ``port``, begins with "exec:", the remainder
+    of the command will be interpreted as a shell command that will
+    be executed in a pseudo-micropython-virtual-environment. As of
+    right now, this just sets ``MICROPYPATH`` to all of the dependency
+    groups' folders.
+    """
     device = Device(port, password=password)
     content = file.read_text()
     device(content)

--- a/belay/cli/run.py
+++ b/belay/cli/run.py
@@ -13,11 +13,14 @@ def run(
 ):
     """Run file on-device.
 
-    If the first argument, ``port``, begins with "exec:", the remainder
-    of the command will be interpreted as a shell command that will
-    be executed in a pseudo-micropython-virtual-environment. As of
-    right now, this just sets ``MICROPYPATH`` to all of the dependency
-    groups' folders.
+    If the first argument, ``port``, is resolvable to an executable,
+    the remainder of the command will be interpreted as a shell command
+    that will be executed in a pseudo-micropython-virtual-environment.
+    As of right now, this just sets ``MICROPYPATH`` to all of the dependency
+    groups' folders. E.g::
+
+            belay run micropython -m unittest
+
     """
     device = Device(port, password=password)
     content = file.read_text()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ readme = "README.rst"
 packages = [{include = "belay"}]
 
 [tool.poetry.scripts]
-belay = "belay.cli.main:app"
+belay = "belay.cli.main:run_app"
 
 [tool.poetry.dependencies]
 # Be as loose as possible if writing a library.

--- a/tests/cli/test_run_exec.py
+++ b/tests/cli/test_run_exec.py
@@ -21,9 +21,10 @@ def project_dir(tmp_path):
 
 def test_run_exec(project_dir, mocker):
     command = ["micropython", "-m", "module"]
-    mock_subprocess = mocker.patch("belay.cli.main.subprocess.check_output")
+    mock_run = mocker.patch("belay.cli.main.subprocess.run")
     run_exec(command)
-    mock_subprocess.assert_called_once_with(
+    mock_run.assert_called_once_with(
         command,
         env=mocker.ANY,
+        check=True,
     )

--- a/tests/cli/test_run_exec.py
+++ b/tests/cli/test_run_exec.py
@@ -1,0 +1,29 @@
+import os
+
+import pytest
+
+from belay.cli.main import run_exec
+
+
+@pytest.fixture
+def project_dir(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        """
+    [tool.belay.dependencies]
+    foo = "foo_uri"
+
+    [tool.belay.group.dev.dependencies]
+    bar = "bar_uri"
+    """
+    )
+    os.chdir(tmp_path)
+
+
+def test_run_exec(project_dir, mocker):
+    command = ["micropython", "-m", "module"]
+    mock_subprocess = mocker.patch("belay.cli.main.subprocess.check_output")
+    run_exec(command)
+    mock_subprocess.assert_called_once_with(
+        command,
+        env=mocker.ANY,
+    )


### PR DESCRIPTION
Adds a pseudo-virtual-environment action to `belay run` if the subsequent port is actually an executable. Currently, just `MICROPYPATH` is set to the local dependencies.