### PR TITLE
move the task definitions to their own file to segregate local form …

### DIFF
--- a/examples/01_blink_led/main.py
+++ b/examples/01_blink_led/main.py
@@ -16,7 +16,13 @@ device = belay.Device(args.port)
 def setup():  # The function name doesn't matter, but is "setup" by convention.
     from machine import Pin
 
-    led = Pin(25, Pin.OUT)
+    print("hello world")
+
+    try:
+        # RP2040 wireless plus others
+        led = Pin.board.LED
+    except (TypeError, AttributeError):
+        led = Pin(25, Pin.OUT)
 
 
 # This sends the function's code over to the board.

--- a/examples/08_device_subclassing/main.py
+++ b/examples/08_device_subclassing/main.py
@@ -2,34 +2,11 @@ import argparse
 import time
 
 from belay import Device
+from mydevice import MyDevice
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--port", "-p", default="/dev/ttyUSB0")
 args = parser.parse_args()
-
-
-class MyDevice(Device):
-    # NOTE: ``Device`` is capatalized here!
-    @Device.setup(
-        autoinit=True
-    )  # ``autoinit=True`` means this method will automatically be called during object creation.
-    def setup():
-        # Code here is executed on-device in a global context.
-        led_pin = Pin(25, Pin.OUT)
-        sensor_temp = ADC(
-            4
-        )  # ADC4 is attached to an internal temperature sensor on the Pi Pico
-
-    @Device.task
-    def set_led(state):
-        led_pin.value(state)
-
-    @Device.task
-    def read_temperature():
-        reading = sensor_temp.read_u16()
-        reading *= 3.3 / 65535  # Convert reading to a voltage.
-        temperature = 27 - (reading - 0.706) / 0.001721  # Convert voltage to Celsius
-        return temperature
 
 
 device = MyDevice(args.port)

--- a/examples/08_device_subclassing/main_multiple_devices.py
+++ b/examples/08_device_subclassing/main_multiple_devices.py
@@ -2,17 +2,12 @@ import argparse
 import time
 
 from belay import Device
+from mydevice import MyDevice
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--device1", default="/dev/ttyUSB0")
 parser.add_argument("--device2", default="/dev/ttyUSB1")
 args = parser.parse_args()
-
-
-class MyDevice(Device):
-    @Device.task
-    def set_led(state):
-        Pin(25, Pin.OUT).value(state)
 
 
 device1 = MyDevice(args.device1)
@@ -21,7 +16,12 @@ device2 = MyDevice(args.device2)
 while True:
     device1.set_led(True)
     device2.set_led(False)
+    temperature = device1.read_temperature()
+    print(f"Temperature 1: {temperature:.1f}C")
+
     time.sleep(0.5)
     device1.set_led(False)
     device2.set_led(True)
+    temperature = device2.read_temperature()
+    print(f"Temperature 2: {temperature:.1f}C")
     time.sleep(0.5)

--- a/examples/08_device_subclassing/mydevice.py
+++ b/examples/08_device_subclassing/mydevice.py
@@ -1,0 +1,28 @@
+from belay import Device
+
+
+class MyDevice(Device):
+    # NOTE: ``Device`` is capatalized here!
+    @Device.setup(
+        autoinit=True
+    )  # ``autoinit=True`` means this method will automatically be called during object creation.
+    def setup():
+        # Code here is executed on-device in a global context.
+        try:
+            # RP2040 wifi plus others
+            led_pin = Pin.board.LED
+        except (TypeError, AttributeError):
+            led_pin = Pin(25, Pin.OUT)  # Example RP2040 w/o wifi
+        # ADC4 is attached to an internal temperature sensor on the Pi Pico
+        sensor_temp = ADC(4)
+
+    @Device.task
+    def set_led(state):
+        led_pin.value(state)
+
+    @Device.task
+    def read_temperature():
+        reading = sensor_temp.read_u16()
+        reading *= 3.3 / 65535  # Convert reading to a voltage.
+        temperature = 27 - (reading - 0.706) / 0.001721  # Convert voltage to Celsius
+        return temperature


### PR DESCRIPTION
Changed the 08_device_subclassing to move the remote tasks into their own file that could be used in either example.  Tested on windows both programs with two RP2040 boards.

Changed the LED for the RP2040 to be board independent.  Pin25 is the LED pin only on the non-wifi board.  This assumes you are using a version of MicroPython 1.19 from the last month.