### PR TITLE
Create an alternative 08B instead of overwriting the existing one

### DIFF
--- a/examples/08B_device_subclassing/README.rst
+++ b/examples/08B_device_subclassing/README.rst
@@ -1,0 +1,24 @@
+Example 08: Device Subclassing
+==============================
+It may be convenient to organize your Belay tasks into a class
+rather than decorated standalone functions. 
+To accomplish this, have your class inherit from ``Device``,
+and mark methods with the ``@Device.task`` decorator.
+Source code of marked methods are sent to the device and executers
+are created when the ``Device`` object is instantiated.
+This also allows for multiple devices to share the same task definitions
+by instantiating multiple objeccts.
+
+Methods marked with ``@Device.setup`` are executed in a global scope. Essentially 
+the contents of the method are extracted and then executed on the device.  
+This means any variables created in ``@Device.setup`` are available to any of the 
+other functions run on the device.
+
+Methods marked with ``@Device.task`` are similar to ``@staticmethod`` in that
+they do **not** contain ``self`` in the method signature.
+To the device, each marked method is equivalent to an independent function.
+
+This is an alternative version of Example 08 that segregates the code
+that runs on the host from the code that will be pushed to the microcontroller.
+Microcontroller targeted code is contained in its own class where it can 
+be reused by both host driver example programs.

--- a/examples/08B_device_subclassing/README.rst
+++ b/examples/08B_device_subclassing/README.rst
@@ -1,4 +1,4 @@
-Example 08: Device Subclassing
+Example 08B: Device Subclassing
 ==============================
 This is an alternative version of Example 08 that explicitly separates
 code that runs on the host (``main.py``, ``main_multiple_devices``)

--- a/examples/08B_device_subclassing/README.rst
+++ b/examples/08B_device_subclassing/README.rst
@@ -1,7 +1,12 @@
 Example 08: Device Subclassing
 ==============================
+This is an alternative version of Example 08 that explicitly separates
+code that runs on the host (``main.py``, ``main_multiple_devices``)
+from the class that contains the code (``MyDevice`` in ``mydevice.py``)
+that will be pushed to the microcontroller.
+
 It may be convenient to organize your Belay tasks into a class
-rather than decorated standalone functions. 
+rather than decorated standalone functions.
 To accomplish this, have your class inherit from ``Device``,
 and mark methods with the ``@Device.task`` decorator.
 Source code of marked methods are sent to the device and executers
@@ -9,16 +14,11 @@ are created when the ``Device`` object is instantiated.
 This also allows for multiple devices to share the same task definitions
 by instantiating multiple objeccts.
 
-Methods marked with ``@Device.setup`` are executed in a global scope. Essentially 
-the contents of the method are extracted and then executed on the device.  
-This means any variables created in ``@Device.setup`` are available to any of the 
+Methods marked with ``@Device.setup`` are executed in a global scope. Essentially
+the contents of the method are extracted and then executed on the device.
+This means any variables created in ``@Device.setup`` are available to any of the
 other functions run on the device.
 
 Methods marked with ``@Device.task`` are similar to ``@staticmethod`` in that
 they do **not** contain ``self`` in the method signature.
 To the device, each marked method is equivalent to an independent function.
-
-This is an alternative version of Example 08 that segregates the code
-that runs on the host from the code that will be pushed to the microcontroller.
-Microcontroller targeted code is contained in its own class where it can 
-be reused by both host driver example programs.

--- a/examples/08B_device_subclassing/main.py
+++ b/examples/08B_device_subclassing/main.py
@@ -1,7 +1,6 @@
 import argparse
 import time
 
-from belay import Device
 from mydevice import MyDevice
 
 parser = argparse.ArgumentParser()

--- a/examples/08B_device_subclassing/main.py
+++ b/examples/08B_device_subclassing/main.py
@@ -1,0 +1,20 @@
+import argparse
+import time
+
+from belay import Device
+from mydevice import MyDevice
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--port", "-p", default="/dev/ttyUSB0")
+args = parser.parse_args()
+
+
+device = MyDevice(args.port)
+
+while True:
+    device.set_led(True)
+    temperature = device.read_temperature()
+    print(f"Temperature: {temperature:.1f}C")
+    time.sleep(0.5)
+    device.set_led(False)
+    time.sleep(0.5)

--- a/examples/08B_device_subclassing/main_multiple_devices.py
+++ b/examples/08B_device_subclassing/main_multiple_devices.py
@@ -1,0 +1,27 @@
+import argparse
+import time
+
+from belay import Device
+from mydevice import MyDevice
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--device1", default="/dev/ttyUSB0")
+parser.add_argument("--device2", default="/dev/ttyUSB1")
+args = parser.parse_args()
+
+
+device1 = MyDevice(args.device1)
+device2 = MyDevice(args.device2)
+
+while True:
+    device1.set_led(True)
+    device2.set_led(False)
+    temperature = device1.read_temperature()
+    print(f"Temperature 1: {temperature:.1f}C")
+
+    time.sleep(0.5)
+    device1.set_led(False)
+    device2.set_led(True)
+    temperature = device2.read_temperature()
+    print(f"Temperature 2: {temperature:.1f}C")
+    time.sleep(0.5)

--- a/examples/08B_device_subclassing/main_multiple_devices.py
+++ b/examples/08B_device_subclassing/main_multiple_devices.py
@@ -1,7 +1,6 @@
 import argparse
 import time
 
-from belay import Device
 from mydevice import MyDevice
 
 parser = argparse.ArgumentParser()

--- a/examples/08B_device_subclassing/mydevice.py
+++ b/examples/08B_device_subclassing/mydevice.py
@@ -1,0 +1,28 @@
+from belay import Device
+
+
+class MyDevice(Device):
+    # NOTE: ``Device`` is capatalized here!
+    @Device.setup(
+        autoinit=True
+    )  # ``autoinit=True`` means this method will automatically be called during object creation.
+    def setup():
+        # Code here is executed on-device in a global context.
+        try:
+            # RP2040 wifi plus others
+            led_pin = Pin.board.LED
+        except (TypeError, AttributeError):
+            led_pin = Pin(25, Pin.OUT)  # Example RP2040 w/o wifi
+        # ADC4 is attached to an internal temperature sensor on the Pi Pico
+        sensor_temp = ADC(4)
+
+    @Device.task
+    def set_led(state):
+        led_pin.value(state)
+
+    @Device.task
+    def read_temperature():
+        reading = sensor_temp.read_u16()
+        reading *= 3.3 / 65535  # Convert reading to a voltage.
+        temperature = 27 - (reading - 0.706) / 0.001721  # Convert voltage to Celsius
+        return temperature

--- a/examples/08_device_subclassing/README.rst
+++ b/examples/08_device_subclassing/README.rst
@@ -1,7 +1,7 @@
 Example 08: Device Subclassing
 ==============================
 It may be convenient to organize your Belay tasks into a class
-rather than decorated standalone functions. 
+rather than decorated standalone functions.
 To accomplish this, have your class inherit from ``Device``,
 and mark methods with the ``@Device.task`` decorator.
 Source code of marked methods are sent to the device and executers
@@ -9,9 +9,9 @@ are created when the ``Device`` object is instantiated.
 This also allows for multiple devices to share the same task definitions
 by instantiating multiple objeccts.
 
-Methods marked with ``@Device.setup`` are executed in a global scope. Essentially 
-the contents of the method are extracted and then executed on the device.  
-This means any variables created in ``@Device.setup`` are available to any of the 
+Methods marked with ``@Device.setup`` are executed in a global scope. Essentially
+the contents of the method are extracted and then executed on the device.
+This means any variables created in ``@Device.setup`` are available to any of the
 other functions run on the device.
 
 Methods marked with ``@Device.task`` are similar to ``@staticmethod`` in that

--- a/examples/08_device_subclassing/README.rst
+++ b/examples/08_device_subclassing/README.rst
@@ -1,13 +1,18 @@
 Example 08: Device Subclassing
 ==============================
 It may be convenient to organize your Belay tasks into a class
-rather than decorated standalone functions.
+rather than decorated standalone functions. 
 To accomplish this, have your class inherit from ``Device``,
 and mark methods with the ``@Device.task`` decorator.
 Source code of marked methods are sent to the device and executers
 are created when the ``Device`` object is instantiated.
 This also allows for multiple devices to share the same task definitions
 by instantiating multiple objeccts.
+
+Methods marked with ``@Device.setup`` are executed in a global scope. Essentially 
+the contents of the method are extracted and then executed on the device.  
+This means any variables created in ``@Device.setup`` are available to any of the 
+other functions run on the device.
 
 Methods marked with ``@Device.task`` are similar to ``@staticmethod`` in that
 they do **not** contain ``self`` in the method signature.


### PR DESCRIPTION
Create an alternative to 08_device_subclassing that moves the remote tasks into their own file that could be used in either example. Tested on windows both programs with two RP2040 boards.

Changed the LED for the RP2040 to be board independent. Pin25 is the LED pin only on the non-wifi board. This assumes you are using a version of MicroPython 1.19 from Jan 2023.