### PR TITLE
Dependencies location

### DIFF
--- a/belay/packagemanager/models.py
+++ b/belay/packagemanager/models.py
@@ -1,10 +1,22 @@
 """Pydantic models for validation Belay configuration.
 """
 
+from functools import partial
+from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import root_validator, validator
+
+validator_reuse = partial(validator, allow_reuse=True)
+
+
+def _dependencies_validator(dependencies):
+    for group_name, _group_value in dependencies.items():
+        if not group_name.isidentifier():
+            raise ValueError("Dependency group name must be a valid python identifier.")
+        # TODO: validate and probably cast group_value into a DependencyConfig type.
+    return dependencies
 
 
 class BaseModel(PydanticBaseModel):
@@ -12,26 +24,40 @@ class BaseModel(PydanticBaseModel):
         allow_mutation = False
 
 
+class DependencyConfig(BaseModel):
+    # TODO
+    pass
+
+
 class GroupConfig(BaseModel):
     optional: bool = False
     dependencies: Dict[str, Union[List, str]] = {}  # TODO allow dict value type.
 
-    @validator("dependencies")
-    def keys_are_python_identifiers(cls, v):
-        for group_name in v:
-            if not group_name.isidentifier():
-                raise ValueError(
-                    "Dependency group name must be a valid python identifier."
-                )
-        return v
+    ##############
+    # VALIDATORS #
+    ##############
+    _v_dependencies = validator_reuse("dependencies")(_dependencies_validator)
 
 
 class BelayConfig(BaseModel):
     """Configuration schema under the ``tool.belay`` section of ``pyproject.toml``."""
 
+    # Name/Folder of project's primary micropython code.
     name: Optional[str] = None
-    dependencies: Dict = {}  # "main" dependencies
-    group: Dict[str, GroupConfig] = {}  # Other dependencies
+
+    # "main" dependencies
+    dependencies: Dict[str, Union[List, str]] = {}  # TODO allow dict value type.
+
+    # Path to where dependency groups should be stored relative to project's root.
+    dependencies_path: Path = Path(".belay/dependencies")
+
+    # Other dependencies
+    group: Dict[str, GroupConfig] = {}
+
+    ##############
+    # VALIDATORS #
+    ##############
+    _v_dependencies = validator_reuse("dependencies")(_dependencies_validator)
 
     @validator("group")
     def main_not_in_group(cls, v):

--- a/belay/project.py
+++ b/belay/project.py
@@ -33,7 +33,8 @@ def find_belay_folder() -> Path:
 
 @lru_cache
 def find_dependencies_folder() -> Path:
-    return find_belay_folder() / "dependencies"
+    config = load_pyproject()
+    return find_project_folder() / config.dependencies_path
 
 
 @lru_cache


### PR DESCRIPTION
* Allow the dependency folder to be specified in `pyproject.toml`. This is to stage a feature where the belay package manager could be used to aid bundling of code to sync to device.
* Preprocess pyproject.toml's dependency specification with pydantic