### PR TITLE
move convenience imports above __pre_autoinit__, since it's useful to…

### DIFF
--- a/belay/device.py
+++ b/belay/device.py
@@ -297,8 +297,6 @@ class Device(Registry):
                 executer,
             )
 
-        self.__pre_autoinit__()
-
         if startup is None:
             if self.implementation.name == "circuitpython":
                 self._exec_snippet("convenience_imports_circuitpython")
@@ -306,6 +304,8 @@ class Device(Registry):
                 self._exec_snippet("convenience_imports_micropython")
         elif startup:
             self(startup)
+
+        self.__pre_autoinit__()
 
         autoinit_executers = _sort_executers(autoinit_executers)
         for executer in autoinit_executers:

--- a/docs/source/Quick Start.rst
+++ b/docs/source/Quick Start.rst
@@ -247,7 +247,7 @@ The decorated method must have no parameters, otherwise a ``ValueError`` will be
 
 The ``Device`` class also has some hook methods that can be implemented to give customization to the object initialization process:
 
-1. ``__pre_autoinit__`` - Called near the end of ``__init__``, but before methods marked with ``@Device.setup(autoinit=True)`` are invoked. This is a good location to sync additional micropython dependencies to device.
+1. ``__pre_autoinit__`` - Called near the end of ``__init__``, after convenience imports have been imported, but before methods marked with ``@Device.setup(autoinit=True)`` are invoked. This is a good location to sync additional micropython dependencies to device.
 
 2. ``__post_init__`` -  Called at the very end of ``__init__``. This is a good location to set custom object attributes.
 


### PR DESCRIPTION
… have those imports available to the hook