### PR TITLE
Editable dependencies (develop)

### DIFF
--- a/belay/cli/main.py
+++ b/belay/cli/main.py
@@ -20,7 +20,7 @@ from belay.cli.sync import sync
 from belay.cli.update import update
 from belay.project import load_groups
 
-app = typer.Typer(no_args_is_help=True)
+app = typer.Typer(no_args_is_help=True, pretty_exceptions_enable=False)
 app.add_typer(cache.app, name="cache")
 
 app.command()(clean)

--- a/belay/packagemanager/group.py
+++ b/belay/packagemanager/group.py
@@ -8,7 +8,11 @@ from typing import List, Optional
 from rich.console import Console
 
 from belay.packagemanager.downloaders import download_uri
-from belay.packagemanager.models import DependencySourceConfig, GroupConfig
+from belay.packagemanager.models import (
+    DependencySourceConfig,
+    GroupConfig,
+    walk_dependencies,
+)
 from belay.packagemanager.sync import sync
 from belay.typing import PathType
 
@@ -154,10 +158,9 @@ def _verify_files(path: PathType):
 
 
 def _walk_develop_dependencies(packages: dict):
-    for package_name, dependencies in packages.items():
-        for dependency in dependencies:
-            if dependency.develop:
-                yield package_name, dependency
+    for package_name, dependency in walk_dependencies(packages):
+        if dependency.develop:
+            yield package_name, dependency
 
 
 def _download_and_verify_dependency(

--- a/belay/packagemanager/models.py
+++ b/belay/packagemanager/models.py
@@ -19,6 +19,8 @@ class BaseModel(PydanticBaseModel):
 
 class DependencySourceConfig(BaseModel):
     uri: str
+    develop: bool = False  # If true, local dependency is in "editable" mode.
+
     rename_to_init: bool = False
 
 
@@ -68,6 +70,8 @@ def _dependencies_preprocessor(dependencies) -> dict[str, List[dict]]:
                     raise NotImplementedError
             group_value = group_value_out
         elif isinstance(group_value, dict):
+            group_value = group_value.copy()
+            group_value.setdefault("rename_to_init", True)
             group_value = [group_value]
         elif isinstance(group_value, DependencySourceConfig):
             # Nothing to do

--- a/docs/source/Package Manager.rst
+++ b/docs/source/Package Manager.rst
@@ -36,21 +36,27 @@ This section contains a mapping of package names to URIs where they can be fetch
 There isn't a strong centralized micropython package repository, so Belay relies on directly specifying python file URLs.
 Belay supports several dependency values:
 
-1. A string to a local file/folder path.
+1. A string to a local file/folder path:
 
    .. code-block:: toml
 
       pathlib = "../micropython-lib/python-stdlib/pathlib/pathlib.py"
       os = "../micropython-lib/python-stdlib/os/os"
 
-2. A github link to a single file or a folder
+2. A github link to a single file or a folder:
 
    .. code-block:: toml
 
       pathlib = "https://github.com/micropython/micropython-lib/blob/master/python-stdlib/pathlib/pathlib.py"
       os = "https://github.com/micropython/micropython-lib/tree/master/python-stdlib/os/os"
 
-3. A list of any of the above if multiple files are required for a single package. This is most common for packages that have optional submodules.
+3. A dictionary with a detailed specification:
+
+   .. code-block:: toml
+
+      pathlib = {uri="../micropython-lib/python-stdlib/pathlib/pathlib.py", develop=true}
+
+4. A list of any of the above if multiple files are required for a single package:
 
    .. code-block:: toml
 
@@ -59,7 +65,17 @@ Belay supports several dependency values:
           "https://github.com/micropython/micropython-lib/blob/master/python-stdlib/os-path/os/path.py",
       ]
 
+   This is most common for packages that have optional submodules.
+
 Support for other types can be added. Please open up a github issue if Belay doesn't support a desired file source.
+
+If specifying a dependency via dictionary, the following fields are available:
+
+* ``uri`` - local or remote path to fetch data from. **Must** be provided.
+
+* ``develop`` - Dependency is in "editable" mode. The dependency source is directly used during ``belay install``.
+  Primarily used for a local dependency actively under development.
+  Defaults to ``False``.
 
 Groups
 ~~~~~~

--- a/tests/packagemanager/test_models.py
+++ b/tests/packagemanager/test_models.py
@@ -1,0 +1,15 @@
+import pydantic
+import pytest
+
+from belay.packagemanager import GroupConfig
+
+
+def test_group_config_multiple_rename_to_init():
+    dependencies = {
+        "package": [
+            {"uri": "foo", "rename_to_init": True},
+            {"uri": "bar", "rename_to_init": True},
+        ]
+    }
+    with pytest.raises(pydantic.ValidationError):
+        GroupConfig(dependencies=dependencies)


### PR DESCRIPTION
* Allows dictionary dependency specifications.
* Add dependency option `develop`.
* Additional validator: only 1 dependency source per package can have ``rename_to_init=True``.