### PR TITLE
Fix "belay run micropython" for dependencies where develop=true.

### DIFF
--- a/belay/packagemanager/downloaders/common.py
+++ b/belay/packagemanager/downloaders/common.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from urllib.parse import urlparse
 
 import fsspec
 from autoregistry import Registry
@@ -20,6 +21,19 @@ class NonMatchingURI(Exception):
 # DO NOT decorate with ``@downloaders``, since this must be last.
 def _download_generic(dst: Path, uri: str) -> Path:
     """Downloads a single file or folder to ``dst / <filename>``."""
+    parsed = urlparse(uri)
+
+    if parsed.scheme in ("", "file"):
+        # Local file, make it relative to project root
+        uri_path = Path(uri)
+
+        if not uri_path.is_absolute():
+            from belay.project import find_project_folder
+
+            uri_path = find_project_folder() / uri
+
+        uri = str(uri_path)
+
     if Path(uri).is_dir():
         fs = fsspec.filesystem("file")
         fs.get(uri, str(dst), recursive=True)

--- a/belay/packagemanager/group.py
+++ b/belay/packagemanager/group.py
@@ -60,8 +60,10 @@ class Group:
             else:
                 existing_dep.unlink()
 
-    def copy_to(self, dst) -> None:
+    def copy_to(self, dst: PathType) -> None:
         """Copy Dependencies folder to destination directory to stage for installation."""
+        dst = Path(dst)
+
         if self.folder.exists():
             # Bulk copy over the group contents
             shutil.copytree(self.folder, dst, dirs_exist_ok=True)


### PR DESCRIPTION
Also fixes relative-path dependencies path-resolution when launching from non-project-root directory.