### PR TITLE
Terminal, post-install reset, post-install monitoring.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -29,3 +29,4 @@ extend-immutable-calls =
     Arg
     Option
     Opt
+    chr

--- a/belay/cli/install.py
+++ b/belay/cli/install.py
@@ -1,3 +1,4 @@
+import shutil
 from functools import partial
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -89,15 +90,17 @@ def install(
                 )
 
             if main:
-                sync_device(
-                    main, dst="/main.py", keep=True, progress_update=tasks["main"]
-                )
+                # Copy provided main to temporary directory in case it's not named main.py
+                main_tmp = tmp_dir / "main.py"
+                shutil.copy(main, main_tmp)
+                sync_device(main_tmp, progress_update=tasks["main"])
 
         if run:
             content = run.read_text()
             device(content)
-        else:
-            # Reset device so ``main.py`` has a chance to execute.
-            device.soft_reset()
-            if follow:
-                device.terminal(exit_char=chr(0x03))  # ctrl-c to exit
+            return
+
+        # Reset device so ``main.py`` has a chance to execute.
+        device.soft_reset()
+        if follow:
+            device.terminal(exit_char=chr(0x03))  # ctrl-c to exit

--- a/belay/cli/install.py
+++ b/belay/cli/install.py
@@ -73,9 +73,11 @@ def install(
     if main:
         with Device(port, password=password) as device:
             device.sync(main, keep=True, mpy_cross_binary=mpy_cross_binary)
-            if follow and not run:
+            if not run:
+                # Reset device so ``main.py`` executes.
                 device.soft_reset()
-                device.terminal(exit_char=chr(0x03))  # ctrl-c to exit
+                if follow:
+                    device.terminal(exit_char=chr(0x03))  # ctrl-c to exit
 
     if run:
         run_cmd(port=port, file=run, password=password)

--- a/belay/cli/install.py
+++ b/belay/cli/install.py
@@ -24,6 +24,9 @@ def install(
     with_groups: List[str] = Option(
         None, "--with", help="Include specified optional dependency group."
     ),
+    follow: bool = Option(
+        False, "--follow", "-f", help="Follow the stdout after upload."
+    ),
 ):
     """Sync dependencies and project itself to device."""
     if run and run.suffix != ".py":
@@ -70,6 +73,9 @@ def install(
     if main:
         with Device(port, password=password) as device:
             device.sync(main, keep=True, mpy_cross_binary=mpy_cross_binary)
+            if follow and not run:
+                device.soft_reset()
+                device.terminal(exit_char=chr(0x03))  # ctrl-c to exit
 
     if run:
         run_cmd(port=port, file=run, password=password)

--- a/belay/cli/main.py
+++ b/belay/cli/main.py
@@ -18,6 +18,7 @@ from belay.cli.install import install
 from belay.cli.new import new
 from belay.cli.run import run
 from belay.cli.sync import sync
+from belay.cli.terminal import terminal
 from belay.cli.update import update
 from belay.project import load_groups
 
@@ -32,6 +33,7 @@ app.command()(install)
 app.command()(new)
 app.command()(run)
 app.command()(sync)
+app.command()(terminal)
 app.command()(update)
 
 

--- a/belay/cli/run.py
+++ b/belay/cli/run.py
@@ -22,7 +22,6 @@ def run(
             belay run micropython -m unittest
 
     """
-    device = Device(port, password=password)
     content = file.read_text()
-    device(content)
-    device.close()
+    with Device(port, password=password) as device:
+        device(content)

--- a/belay/cli/terminal.py
+++ b/belay/cli/terminal.py
@@ -1,0 +1,16 @@
+from typer import Argument, Option
+
+from belay import Device
+from belay.cli.common import help_password, help_port
+
+
+def terminal(
+    port: str = Argument(..., help=help_port),
+    password: str = Option("", help=help_password),
+):
+    """Open up an interactive REPL.
+
+    Press ctrl+] to exit.
+    """
+    with Device(port, password=password) as device:
+        device.terminal()

--- a/belay/device.py
+++ b/belay/device.py
@@ -231,6 +231,10 @@ class MethodMetadata:
 class Device(Registry):
     """Belay interface into a micropython device.
 
+    Can be used as a context manager; calls ``self.close`` on exit.
+
+    Inherits from ``autoregistry.Registry`` for easy access to subclasses.
+
     Attributes
     ----------
     implementation: Implementation
@@ -649,7 +653,10 @@ class Device(Registry):
         self.close()
 
     def close(self) -> None:
-        """Close the connection to device."""
+        """Close the connection to device.
+
+        Automatically called on context manager exit.
+        """
         # Invoke all teardown executers prior to closing out connection.
         if self._board is None:
             # Has already been closed
@@ -827,7 +834,7 @@ class Device(Registry):
         return f
 
     def terminal(self, *, exit_char=chr(0x1D)):
-        """Start a blocking terminal over the serial port."""
+        """Start a blocking interactive terminal over the serial port."""
         self._board.exit_raw_repl()  # In case we were previously in raw repl mode.
         miniterm = Miniterm(self._board.serial)
         miniterm.set_rx_encoding("UTF-8")

--- a/belay/exceptions.py
+++ b/belay/exceptions.py
@@ -11,9 +11,9 @@ class FeatureUnavailableError(BelayException):
 
 
 class SpecialFunctionNameError(BelayException):
-    """Reserved function name that may impact Belay functionality.
+    """Attempted to use a reserved Belay function name.
 
-    Currently limited to:
+    The following name rules are reserved:
 
         * Names that start and end with double underscore, ``__``.
 

--- a/belay/helpers.py
+++ b/belay/helpers.py
@@ -37,7 +37,7 @@ def list_devices() -> List[str]:
 
     Returns
     -------
-    list[str]
+    List[str]
         Available devices identifiers.
     """
     return [port.device for port in list_ports.comports()]

--- a/belay/pyboard.py
+++ b/belay/pyboard.py
@@ -406,6 +406,10 @@ class Pyboard:
         """Interrupts any running program."""
         self.serial.write(b"\r\x03\x03")  # ctrl-C twice: interrupt any running program
 
+    def ctrl_d(self):
+        # Note: When in raw repl mode, a soft-reset will NOT execute ``main.py``.
+        self.serial.write(b"\x04")  # ctrl-D: soft reset
+
     def enter_raw_repl(self, soft_reset=True):
         # flush input (without relying on serial.flushInput())
         n = self.serial.inWaiting()
@@ -418,7 +422,7 @@ class Pyboard:
         self.serial.write(b"\r\x01")  # ctrl-A: enter raw REPL
         if soft_reset:
             self.read_until(1, b"raw REPL; CTRL-B to exit\r\n>")
-            self.serial.write(b"\x04")  # ctrl-D: soft reset
+            self.ctrl_d()
 
         self.read_until(1, b"raw REPL; CTRL-B to exit\r\n")
         self.in_raw_repl = True

--- a/docs/source/Package Manager.rst
+++ b/docs/source/Package Manager.rst
@@ -178,8 +178,15 @@ To additionally sync a script to ``/main.py``, specify the script using the ``--
 
    belay install [PORT] --main main.py
 
+The output of the ``main`` script can be monitored after flashing by including the ``--follow`` flag.
+
+.. code-block:: bash
+
+   belay install [PORT] --main main.py --follow
+
 During development, it is often convenient to specify a script to run without actually syncing it to ``/main.py``.
 For this, specify the script using the ``--run`` option.
+The output will always be monitored.
 
 .. code-block:: bash
 
@@ -291,6 +298,13 @@ This confirmation prompt can be bypassed by specifying the ``--yes`` flag.
 
    belay cache clear --all --yes
 
+terminal
+--------
+Opens up an interactive terminal with the device.
+
+.. code-block:: bash
+
+   belay terminal [PORT]
 
 Q&A
 ^^^

--- a/docs/source/Package Manager.rst
+++ b/docs/source/Package Manager.rst
@@ -173,12 +173,14 @@ Syncs the project and dependencies to device.
    belay install [PORT]
 
 To additionally sync a script to ``/main.py``, specify the script using the ``--main`` option.
+After flashing, the device will be reset and the ``main`` script will execute.
 
 .. code-block:: bash
 
    belay install [PORT] --main main.py
 
 The output of the ``main`` script can be monitored after flashing by including the ``--follow`` flag.
+Cancel the running script and exit the monitor via ``ctrl-c``.
 
 .. code-block:: bash
 
@@ -301,6 +303,7 @@ This confirmation prompt can be bypassed by specifying the ``--yes`` flag.
 terminal
 --------
 Opens up an interactive terminal with the device.
+Press ``ctrl-]`` to exit the terminal.
 
 .. code-block:: bash
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,7 +1,24 @@
 API
 ===
 
-.. automodule:: belay
+Device
+^^^^^^
+.. autoclass:: belay.Device
+   :members:
+   :undoc-members:
+   :exclude-members: clear, get, items, keys, values
+
+.. autoclass:: belay.Implementation
+   :members:
+   :undoc-members:
+
+Helpers
+^^^^^^^
+.. autofunction:: belay.list_devices
+
+Exceptions
+^^^^^^^^^^
+.. automodule:: belay.exceptions
    :members:
    :undoc-members:
    :show-inheritance:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ class MockDevice:
     def __init__(self, mocker):
         self.mocker = mocker
         self.inst = mocker.MagicMock()
+        self.inst.__enter__.return_value = self.inst  # Support context manager use.
         self.cls = None
 
     def patch(self, target: str):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -9,7 +9,7 @@ def mock_pyboard(mocker):
     exec_side_effect = [b'_BELAYR("micropython", (1, 19, 1), "rp2")\r\n'] * 100
 
     def mock_init(self, *args, **kwargs):
-        self.serial = None
+        self.serial = mocker.MagicMock()
 
     def mock_exec(cmd, data_consumer=None):
         data = exec_side_effect.pop()
@@ -24,8 +24,8 @@ def mock_pyboard(mocker):
 
 @pytest.fixture
 def mock_device(mock_pyboard):
-    device = belay.Device()
-    return device
+    with belay.Device() as device:
+        yield device
 
 
 def test_device_init(mock_device):

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -22,7 +22,7 @@ def __belay_ilistdir(x):
 @pytest.fixture
 def mock_pyboard(mocker):
     def mock_init(self, *args, **kwargs):
-        self.serial = None
+        self.serial = mocker.MagicMock()
 
     exec_side_effect = [b'_BELAYR("micropython", (1, 19, 1), "rp2")\r\n'] * 100
 


### PR DESCRIPTION
* Inclusion of an interactive terminal:
    * The `Device` class now has a method `terminal()` that will start a blocking interactive terminal.
    * New command: `belay terminal [port]` to open up an interactive terminal with the device.
* Improvements to `belay install`:
    * If `--main my_script.py` is specified, device will now restart after installation so that the script will automatically execute.
    * New flag `--follow`: after flashing, the output of the main script will be monitored and printed to stdout. Press `ctrl-c` to exit.