### PR TITLE
UsbSpecifier for fine-grained device target selection.

### DIFF
--- a/belay/__init__.py
+++ b/belay/__init__.py
@@ -3,13 +3,16 @@ __version__ = "0.0.0"
 
 __all__ = [
     "AuthenticationError",
+    "ConnectionFailedError",
     "ConnectionLost",
     "Device",
+    "DeviceNotFoundError",
     "FeatureUnavailableError",
     "Implementation",
     "MaxHistoryLengthError",
     "PyboardException",
     "SpecialFunctionNameError",
+    "UsbSpecifier",
     "list_devices",
     "minify",
 ]
@@ -17,10 +20,13 @@ from ._minify import minify
 from .device import Device, Implementation
 from .exceptions import (
     AuthenticationError,
+    ConnectionFailedError,
     ConnectionLost,
+    DeviceNotFoundError,
     FeatureUnavailableError,
     MaxHistoryLengthError,
     SpecialFunctionNameError,
 )
 from .helpers import list_devices
 from .pyboard import PyboardException
+from .usb_specifier import UsbSpecifier

--- a/belay/exceptions.py
+++ b/belay/exceptions.py
@@ -25,7 +25,15 @@ class MaxHistoryLengthError(BelayException):
     """Too many commands were given."""
 
 
-class ConnectionLost(BelayException):  # noqa: N818
+class DeviceNotFoundError(BelayException):
+    """Unable to find specified device."""
+
+
+class ConnectionFailedError(BelayException):
+    """Unable to connect to specified device."""
+
+
+class ConnectionLost(ConnectionFailedError):  # noqa: N818
     """Lost connection to device."""
 
 

--- a/belay/usb_specifier.py
+++ b/belay/usb_specifier.py
@@ -1,0 +1,51 @@
+from typing import Dict, Optional
+
+from pydantic import BaseModel
+from serial.tools.list_ports import comports
+
+from .exceptions import DeviceNotFoundError
+
+
+def _normalize(val):
+    """Normalize ``val`` for comparison."""
+    if isinstance(val, str):
+        return val.casefold()
+    return val
+
+
+def _dict_is_subset(subset: Dict, superset: Dict) -> bool:
+    """Tests if ``subset`` dictionary is a subset of ``superset`` dictionary."""
+    for subset_key, subset_value in subset.items():
+        try:
+            superset_value = superset[subset_key]
+        except KeyError:
+            return False
+
+        if _normalize(subset_value) != _normalize(superset_value):
+            return False
+    return True
+
+
+class UsbSpecifier(BaseModel):
+    vid: Optional[int] = None
+    pid: Optional[int] = None
+    serial_number: Optional[str] = None
+    manufacturer: Optional[str] = None
+    product: Optional[str] = None
+
+    def to_port(self) -> str:
+        spec = self.dict(exclude_none=True)
+        possible_matches = []
+
+        for port_info in comports():
+            if _dict_is_subset(spec, vars(port_info)):
+                possible_matches.append(port_info)
+        if not possible_matches:
+            raise DeviceNotFoundError
+        elif len(possible_matches) > 1:
+            message = "Multiple potential devices found:\n" + "\n".join(
+                f"    {vars(x)}" for x in possible_matches
+            )
+            raise DeviceNotFoundError(message)
+
+        return possible_matches[0].device

--- a/tests/test_usb_specifier.py
+++ b/tests/test_usb_specifier.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from belay import UsbSpecifier
+from belay.exceptions import DeviceNotFoundError
+
+
+@dataclass
+class ListPortInfo:
+    device: str
+    name: str
+    description: str = "n/a"
+    hwid: str = "n/a"
+    vid: Optional[int] = None
+    pid: Optional[int] = None
+    serial_number: Optional[str] = None
+    location: Optional[str] = None
+    manufacturer: Optional[str] = None
+    product: Optional[str] = None
+    interface: Optional[str] = None
+
+
+@pytest.fixture
+def mock_comports(mocker):
+    mock_comports = mocker.patch(
+        "belay.usb_specifier.comports",
+        return_value=iter(
+            [
+                ListPortInfo(
+                    device="/dev/ttyUSB0",
+                    name="ttyUSB0",
+                    pid=10,
+                    vid=20,
+                    manufacturer="Belay Industries",
+                    serial_number="abc123",
+                ),
+                ListPortInfo(
+                    device="/dev/ttyUSB1",
+                    name="ttyUSB1",
+                    pid=11,
+                    vid=21,
+                    manufacturer="Belay Industries",
+                    serial_number="xyz987",
+                ),
+            ]
+        ),
+    )
+    return mock_comports
+
+
+def test_usb_specifier_serial_number_only(mock_comports):
+    spec = UsbSpecifier(serial_number="abc123")
+    assert spec.to_port() == "/dev/ttyUSB0"
+
+
+def test_usb_specifier_no_matches(mock_comports):
+    with pytest.raises(DeviceNotFoundError):
+        UsbSpecifier(manufacturer="Foo").to_port()
+
+
+def test_usb_specifier_multiple_matches(mock_comports):
+    with pytest.raises(DeviceNotFoundError):
+        UsbSpecifier(manufacturer="Belay Industries").to_port()


### PR DESCRIPTION
Continuing discussion from #60 .  There is a desire to be able to specify the micropython board by attributes like pid/vid/serial_number. This PR aims to address that.

This PR introduces the class `UsbSpecifier` that takes in a variety of optional keyword arguments. The resulting object can be passed into `belay.Device`. If an attached board matches all of the specified keyword arguments (like `serial_number`, `pid`, etc), then it will be used. If no device is found, or if multiple devices match the provided specifier, then an exception is raised.

@raveslave, this PR is not yet complete, but so far it's in a working state. Would like feedback on naming/usage, and if it satisfies your needs. I'm not a huge fan of the current name `UsbSpecifier` and am open to suggestions. Aside from feedback, items that need to be completed before merging this PR:

1. Update docs
2. Maybe add new CLI features for making this easier; maybe modify the existing `belay identify` command.

Example usage:

```
from belay import Device, UsbSpecifier
device = Device(
    UsbSpecifier(
        serial_number="abc123",
    )
)
```