### PR TITLE
Implementation specific executers

### DIFF
--- a/belay/__init__.py
+++ b/belay/__init__.py
@@ -11,6 +11,8 @@ __all__ = [
     "Implementation",
     "InsufficientSpecifierError",
     "MaxHistoryLengthError",
+    "NoMatchingExecuterError",
+    "NotBelayResponseError",
     "PyboardException",
     "SpecialFunctionNameError",
     "UsbSpecifier",
@@ -27,6 +29,8 @@ from .exceptions import (
     FeatureUnavailableError,
     InsufficientSpecifierError,
     MaxHistoryLengthError,
+    NoMatchingExecuterError,
+    NotBelayResponseError,
     SpecialFunctionNameError,
 )
 from .helpers import list_devices

--- a/belay/__init__.py
+++ b/belay/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "ConnectionFailedError",
     "ConnectionLost",
     "Device",
+    "DeviceMeta",
     "DeviceNotFoundError",
     "FeatureUnavailableError",
     "Implementation",
@@ -21,6 +22,7 @@ __all__ = [
 ]
 from ._minify import minify
 from .device import Device, Implementation
+from .device_meta import DeviceMeta
 from .exceptions import (
     AuthenticationError,
     ConnectionFailedError,

--- a/belay/cli/select.py
+++ b/belay/cli/select.py
@@ -1,0 +1,25 @@
+import questionary
+
+from belay import Device
+
+
+class Blinker(Device):
+    def setup_neopixel(self):
+        if self.implementation.name == "circuitpython":
+            raise NotImplementedError
+        else:
+            raise NotImplementedError
+
+    def setup_led(self):
+        if self.implementation.name == "circuitpython":
+            raise NotImplementedError
+        else:
+            raise NotImplementedError
+
+
+def select():
+    """Interactive board selector.
+
+    For determining board-specific metadata for repeatable connections.
+    """
+    pass

--- a/belay/device.py
+++ b/belay/device.py
@@ -106,6 +106,7 @@ class Device(metaclass=DeviceMeta):
 
         self._exec_snippet("startup")
 
+        # Obtain implementation early on so implementation-specific executers can be bound.
         self.implementation = Implementation(
             *self(
                 "(sys.implementation.name, sys.implementation.version, sys.platform)"
@@ -588,6 +589,11 @@ class Device(metaclass=DeviceMeta):
             Automatically invokes decorated functions at the end of object ``__init__``.
             Methods will be executed in order-registered.
             Defaults to ``False``.
+        implementation: str
+            If supplied, the provided method will **only** be used if the board's implementation **name** matches.
+            Several methods of the same name can be overloaded that support different implementations.
+            Common values include "micropython", and "circuitpython".
+            Defaults to an empty string, which **all** implementations will match to.
         """  # noqa: D400
         if f is None:
             return wraps_partial(Device.setup, autoinit=autoinit, implementation=implementation, **kwargs)  # type: ignore[reportGeneralTypeIssues]
@@ -641,6 +647,11 @@ class Device(metaclass=DeviceMeta):
         record: bool
             Each invocation of the executer is recorded for playback upon reconnect.
             Defaults to ``True``.
+        implementation: str
+            If supplied, the provided method will **only** be used if the board's implementation **name** matches.
+            Several methods of the same name can be overloaded that support different implementations.
+            Common values include "micropython", and "circuitpython".
+            Defaults to an empty string, which **all** implementations will match to.
         """  # noqa: D400
         if f is None:
             return wraps_partial(Device.teardown, implementation=implementation, **kwargs)  # type: ignore[reportGeneralTypeIssues]
@@ -692,6 +703,11 @@ class Device(metaclass=DeviceMeta):
             Each invocation of the executer is recorded for playback upon reconnect.
             Only recommended to be set to ``True`` for a setup-like function.
             Defaults to ``False``.
+        implementation: str
+            If supplied, the provided method will **only** be used if the board's implementation **name** matches.
+            Several methods of the same name can be overloaded that support different implementations.
+            Common values include "micropython", and "circuitpython".
+            Defaults to an empty string, which **all** implementations will match to.
         """  # noqa: D400
         if f is None:
             return wraps_partial(Device.task, implementation=implementation, **kwargs)  # type: ignore[reportGeneralTypeIssues]
@@ -735,6 +751,11 @@ class Device(metaclass=DeviceMeta):
         record: bool
             Each invocation of the executer is recorded for playback upon reconnect.
             Defaults to ``True``.
+        implementation: str
+            If supplied, the provided method will **only** be used if the board's implementation **name** matches.
+            Several methods of the same name can be overloaded that support different implementations.
+            Common values include "micropython", and "circuitpython".
+            Defaults to an empty string, which **all** implementations will match to.
         """  # noqa: D400
         if f is None:
             return wraps_partial(Device.task, implementation=implementation, **kwargs)  # type: ignore[reportGeneralTypeIssues]

--- a/belay/device.py
+++ b/belay/device.py
@@ -717,7 +717,6 @@ class Device(metaclass=DeviceMeta):
         )
         return f
 
-    @staticmethod
     @overload
     @staticmethod
     def thread(f: Callable[P, R]) -> Callable[P, R]:

--- a/belay/device.py
+++ b/belay/device.py
@@ -71,7 +71,7 @@ class Device(metaclass=DeviceMeta):
 
     Can be used as a context manager; calls ``self.close`` on exit.
 
-    Inherits from ``autoregistry.Registry`` for easy access to subclasses.
+    Uses the ``autoregistry.RegistryMeta`` metaclass for easy-to-access subclasses.
 
     Attributes
     ----------
@@ -113,7 +113,7 @@ class Device(metaclass=DeviceMeta):
             emitters=self._emitter_check(),
         )
 
-        # Setup private executer generators
+        # Setup executer generators and bind to private attributes.
         executer_generators = {}
         for executer_name, executer_cls in Executer.items():
             executer_generator = executer_cls(self)
@@ -126,7 +126,7 @@ class Device(metaclass=DeviceMeta):
         # executer markers (e.g. ``@Device.task``).
         autoinit_executers = []
         instantiated_executer_names = set()
-        for method_name in vars(type(self)):
+        for method_name in dir(type(self)):
             # Get method from self to trigger descriptors.
             try:
                 method = getattr(self, method_name)

--- a/belay/device_meta.py
+++ b/belay/device_meta.py
@@ -3,10 +3,7 @@
 Inspired by mCoding example::
 
     https://github.com/mCodingLLC/VideosSampleCode/blob/master/videos/077_metaclasses_in_python/overloading.py
-
 """
-from typing import Callable
-
 from autoregistry import RegistryMeta
 
 from .exceptions import NoMatchingExecuterError
@@ -14,11 +11,11 @@ from .exceptions import NoMatchingExecuterError
 _MISSING = object()
 
 
-class _ExecuterList(list):
+class OverloadList(list):
     """To separate user-lists from a list of overloaded methods."""
 
 
-class _OverloadDict(dict):
+class OverloadDict(dict):
     """Dictionary where a key can be written to multiple times."""
 
     def __setitem__(self, key, value):
@@ -33,9 +30,9 @@ class _OverloadDict(dict):
 
         if prior_val is _MISSING:
             # Register a new method name
-            insert_val = _ExecuterList([value]) if method_metadata else value
+            insert_val = OverloadList([value]) if method_metadata else value
             super().__setitem__(key, insert_val)
-        elif isinstance(prior_val, _ExecuterList):
+        elif isinstance(prior_val, OverloadList):
             # Add to a previously overloaded method.
             if not method_metadata:
                 raise ValueError(f"Cannot mix non-executer and executer methods: {key}")
@@ -60,10 +57,10 @@ class ExecuterMethod:
         self.name = name
 
     def __init__(self, overload_list):
-        if not isinstance(overload_list, _ExecuterList):
-            raise TypeError("must use OverloadList")
+        if not isinstance(overload_list, OverloadList):
+            raise TypeError("Must use OverloadList.")
         if not overload_list:
-            raise ValueError("empty overload list")
+            raise ValueError("Empty OverloadList.")
         self.overload_list = overload_list
 
     def __repr__(self):
@@ -92,11 +89,11 @@ class ExecuterMethod:
 class DeviceMeta(RegistryMeta):
     @classmethod
     def __prepare__(cls, name, bases, **kwargs):
-        return _OverloadDict()
+        return OverloadDict()
 
     def __new__(cls, name, bases, namespace, **kwargs):
         overload_namespace = {
-            key: ExecuterMethod(val) if isinstance(val, _ExecuterList) else val
+            key: ExecuterMethod(val) if isinstance(val, OverloadList) else val
             for key, val in namespace.items()
         }
         output_cls = super().__new__(cls, name, bases, overload_namespace, **kwargs)

--- a/belay/device_meta.py
+++ b/belay/device_meta.py
@@ -1,5 +1,128 @@
+"""Metaclass to allow executer overloading.
+
+Inspired by mCoding example::
+
+    https://github.com/mCodingLLC/VideosSampleCode/blob/master/videos/077_metaclasses_in_python/overloading.py
+
+"""
+from typing import Callable
+
 from autoregistry import RegistryMeta
+
+from .exceptions import NoMatchingExecuterError
+
+_MISSING = object()
+
+
+class _ExecuterList(list):
+    """To separate user-lists from a list of overloaded methods."""
+
+
+class _OverloadDict(dict):
+    """Dictionary where a key can be written to multiple times."""
+
+    def __setitem__(self, key, value):
+        # Key: method name
+        # Value: method
+
+        if not isinstance(key, str):
+            raise TypeError
+
+        prior_val = self.get(key, _MISSING)
+        method_metadata = getattr(value, "__belay__", False)
+
+        if prior_val is _MISSING:
+            # Register a new method name
+            insert_val = _ExecuterList([value]) if method_metadata else value
+            super().__setitem__(key, insert_val)
+        elif isinstance(prior_val, _ExecuterList):
+            # Add to a previously overloaded method.
+            if not method_metadata:
+                raise ValueError(f"Cannot mix non-executer and executer methods: {key}")
+
+            # Check for a previous "catchall" method
+            for f in prior_val:
+                if not f.__belay__.implementation:
+                    raise ValueError(
+                        f"Cannot define another executor after catchall: {key}."
+                    )
+            prior_val.append(value)
+        else:
+            # Overwrite a previous vanilla method
+            if method_metadata:
+                raise ValueError(f"Cannot mix non-executer and executer methods: {key}")
+            super().__setitem__(key, value)
+
+
+class _Overload:
+    def __set_name__(self, owner, name):
+        self.owner = owner
+        self.name = name
+
+    def __init__(self, overload_list):
+        if not isinstance(overload_list, _ExecuterList):
+            raise TypeError("must use OverloadList")
+        if not overload_list:
+            raise ValueError("empty overload list")
+        self.overload_list = overload_list
+
+    def __repr__(self):
+        return f"{self.__class__.__qualname__}({self.overload_list!r})"
+
+    def __get__(self, instance, _owner=None):
+        if instance is None:
+            return self
+        # don't use owner == type(instance)
+        # we want self.owner, which is the class from which get is being called
+        return BoundOverloadDispatcher(
+            instance, self.owner, self.name, self.overload_list
+        )
+
+
+class BoundOverloadDispatcher:
+    def __init__(self, instance, owner_cls, name, overload_list):
+        self.instance = instance
+        self.owner_cls = owner_cls
+        self.name = name
+        self.overload_list = overload_list
+
+    def best_match(self, *args, **kwargs):
+        target = self.instance.implementation.name
+
+        for f in self.overload_list:
+            imp = f.__belay__.implementation
+
+            if not imp or imp == target:
+                return f
+
+        raise NoMatchingExecuterError()
+
+    def __call__(self, *args, **kwargs):
+        try:
+            f = self.best_match(*args, **kwargs)
+        except NoMatchingExecuterError:
+            pass
+        else:
+            # All executers are static methods, so don't pass in ``self.instance``
+            return f(*args, **kwargs)
+
+        # no matching overload in owner class, check next in line
+        super_instance = super(self.owner_cls, self.instance)
+        super_call = getattr(super_instance, self.name, _MISSING)
+        if super_call is not _MISSING:
+            return super_call(*args, **kwargs)  # type: ignore[reportGeneralTypeIssues]
+        else:
+            raise NoMatchingExecuterError()
 
 
 class DeviceMeta(RegistryMeta):
-    pass
+    @classmethod
+    def __prepare__(cls, name, bases, **kwargs):
+        return _OverloadDict()
+
+    def __new__(cls, name, bases, namespace, **kwargs):
+        overload_namespace = {
+            key: _Overload(val) if isinstance(val, _ExecuterList) else val
+            for key, val in namespace.items()
+        }
+        return super().__new__(cls, name, bases, overload_namespace, **kwargs)

--- a/belay/device_support.py
+++ b/belay/device_support.py
@@ -34,6 +34,8 @@ _method_metadata_counter = 0
 
 @dataclass
 class MethodMetadata:
+    """Metadata for executer-decorated Device methods."""
+
     executer: Callable
     kwargs: dict
     autoinit: bool = False  # Only applies to ``SetupExecuter``.

--- a/belay/exceptions.py
+++ b/belay/exceptions.py
@@ -45,5 +45,9 @@ class InternalError(BelayException):
     """Internal to Belay logic error."""
 
 
-class NotBelayResponseError(Exception):
+class NotBelayResponseError(BelayException):
     """Parsed response wasn't for Belay."""
+
+
+class NoMatchingExecuterError(BelayException):
+    """No valid executer found for the given board Implementation."""

--- a/tests/integration/test_classes.py
+++ b/tests/integration/test_classes.py
@@ -147,69 +147,34 @@ def test_classes_executer_implementation_overload(emulate_command, mocker):
     """Tests if proper overloaded methods are executed depending on implementation."""
 
     class MyDevice(Device, skip=True):
-        @Device.task(implementation="foo")
+        @Device.task(implementation="micropython")
         def test_task():
-            return "foo_task_return_value"
+            return "micropython_task_return_value"
 
-        @Device.task(implementation="bar")
+        @Device.task(implementation="circuitpython")
         def test_task():  # noqa: F811
-            return "bar_task_return_value"
+            return "circuitpython_task_return_value"
+
+        @Device.setup(implementation="micropython")
+        def test_setup():
+            setup_var = "micropython_setup_return_value"  # noqa: F841
+
+        @Device.setup(implementation="circuitpython")
+        def test_setup():  # noqa: F811
+            setup_var = "circuitpython_setup_return_value"  # noqa: F841
 
         @Device.task
-        def test_task():  # noqa: F811
-            return "catchall_task_return_value"
-
-        @Device.setup(implementation="foo")
-        def test_setup():
-            return "foo_setup_return_value"
-
-        @Device.setup(implementation="bar")
-        def test_setup():  # noqa: F811
-            return "bar_setup_return_value"
-
-        @Device.setup()
-        def test_setup():  # noqa: F811
-            return "catchall_setup_return_value"
-
-        @Device.teardown(implementation="foo")
-        def test_teardown():
-            return "foo_teardown_return_value"
-
-        @Device.teardown(implementation="bar")
-        def test_teardown():  # noqa: F811
-            return "bar_teardown_return_value"
-
-        @Device.teardown()
-        def test_teardown():  # noqa: F811
-            return "catchall_teardown_return_value"
+        def get_setup_var():
+            return setup_var  # noqa: F821
 
     with MyDevice(emulate_command) as device:
-        # Tasks
-        device.implementation.name = "foo"
-        assert device.test_task() == "foo_task_return_value"
-
-        device.implementation.name = "bar"
-        assert device.test_task() == "bar_task_return_value"
-
-        device.implementation.name = "baz"
-        assert device.test_task() == "catchall_task_return_value"
-
-        # Setup
-        device.implementation.name = "foo"
-        assert device.test_setup() == "foo_setup_return_value"
-
-        device.implementation.name = "bar"
-        assert device.test_setup() == "bar_setup_return_value"
-
-        device.implementation.name = "baz"
-        assert device.test_setup() == "catchall_setup_return_value"
-
-        # Teardown
-        device.implementation.name = "foo"
-        assert device.test_teardown() == "foo_teardown_return_value"
-
-        device.implementation.name = "bar"
-        assert device.test_teardown() == "bar_teardown_return_value"
-
-        device.implementation.name = "baz"
-        assert device.test_teardown() == "catchall_teardown_return_value"
+        if "--image=micropython" in emulate_command:
+            assert device.test_task() == "micropython_task_return_value"
+            device.test_setup()
+            assert device.get_setup_var() == "micropython_setup_return_value"
+        elif "--image=circuitpython" in emulate_command:
+            assert device.test_task() == "circuitpython_task_return_value"
+            device.test_setup()
+            assert device.get_setup_var() == "circuitpython_setup_return_value"
+        else:
+            raise NotImplementedError

--- a/tests/integration/test_classes.py
+++ b/tests/integration/test_classes.py
@@ -34,6 +34,19 @@ def test_classes_basic(emulate_command):
         assert device.get_times_bar(2) == 84
 
 
+def test_classes_mixin(emulate_command):
+    class Mixin:
+        @Device.task
+        def foo(x):
+            return x * 2
+
+    class MyDevice(Device, Mixin, skip=True):
+        pass
+
+    with MyDevice(emulate_command) as device:
+        assert device.foo(5) == 10
+
+
 def test_classes_setup_arguments(emulate_command):
     class MyDevice(Device, skip=True):
         @Device.setup

--- a/tests/integration/test_classes.py
+++ b/tests/integration/test_classes.py
@@ -141,3 +141,75 @@ def test_classes_teardown_context_manager_mocked(emulate_command, mocker):
         device._belay_teardown._belay_executers[0] = mock_teardown
 
     mock_teardown.assert_called_once()
+
+
+def test_classes_executer_implementation_overload(emulate_command, mocker):
+    """Tests if proper overloaded methods are executed depending on implementation."""
+
+    class MyDevice(Device, skip=True):
+        @Device.task(implementation="foo")
+        def test_task():
+            return "foo_task_return_value"
+
+        @Device.task(implementation="bar")
+        def test_task():  # noqa: F811
+            return "bar_task_return_value"
+
+        @Device.task
+        def test_task():  # noqa: F811
+            return "catchall_task_return_value"
+
+        @Device.setup(implementation="foo")
+        def test_setup():
+            return "foo_setup_return_value"
+
+        @Device.setup(implementation="bar")
+        def test_setup():  # noqa: F811
+            return "bar_setup_return_value"
+
+        @Device.setup()
+        def test_setup():  # noqa: F811
+            return "catchall_setup_return_value"
+
+        @Device.teardown(implementation="foo")
+        def test_teardown():
+            return "foo_teardown_return_value"
+
+        @Device.teardown(implementation="bar")
+        def test_teardown():  # noqa: F811
+            return "bar_teardown_return_value"
+
+        @Device.teardown()
+        def test_teardown():  # noqa: F811
+            return "catchall_teardown_return_value"
+
+    with MyDevice(emulate_command) as device:
+        # Tasks
+        device.implementation.name = "foo"
+        assert device.test_task() == "foo_task_return_value"
+
+        device.implementation.name = "bar"
+        assert device.test_task() == "bar_task_return_value"
+
+        device.implementation.name = "baz"
+        assert device.test_task() == "catchall_task_return_value"
+
+        # Setup
+        device.implementation.name = "foo"
+        assert device.test_setup() == "foo_setup_return_value"
+
+        device.implementation.name = "bar"
+        assert device.test_setup() == "bar_setup_return_value"
+
+        device.implementation.name = "baz"
+        assert device.test_setup() == "catchall_setup_return_value"
+
+        # Teardown
+        device.implementation.name = "foo"
+        assert device.test_teardown() == "foo_teardown_return_value"
+
+        device.implementation.name = "bar"
+        assert device.test_teardown() == "bar_teardown_return_value"
+
+        device.implementation.name = "baz"
+        assert device.test_teardown() == "catchall_teardown_return_value"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -3,6 +3,7 @@ import pytest
 import belay
 import belay.device
 from belay import Device
+from belay.exceptions import NoMatchingExecuterError
 
 
 @pytest.fixture
@@ -165,3 +166,13 @@ def test_overload_executer_after_catchall_error():
             @Device.task(implementation="circuitpython")
             def foo():  # noqa: F811
                 pass
+
+
+def test_overload_executer_no_matching_error(mock_pyboard):
+    class MyDevice(Device):
+        @Device.task(implementation="missing_implementation")
+        def foo():
+            pass
+
+    with pytest.raises(NoMatchingExecuterError):
+        MyDevice()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2,6 +2,7 @@ import pytest
 
 import belay
 import belay.device
+from belay import Device
 
 
 @pytest.fixture
@@ -129,3 +130,38 @@ def test_parse_belay_response_r():
     assert {1} == belay.device.parse_belay_response("_BELAYR{1}")
     assert belay.device.parse_belay_response("_BELAYRb'foo'") == b"foo"
     assert belay.device.parse_belay_response("_BELAYRFalse") is False
+
+
+def test_overload_executer_mixing_error():
+    with pytest.raises(ValueError):
+
+        class MyDevice1(Device, skip=True):
+            def foo():
+                pass
+
+            @Device.task(implementation="circuitpython")
+            def foo():  # noqa: F811
+                pass
+
+    with pytest.raises(ValueError):
+
+        class MyDevice2(Device, skip=True):
+            @Device.task(implementation="circuitpython")
+            def foo():
+                pass
+
+            def foo():  # noqa: F811
+                pass
+
+
+def test_overload_executer_after_catchall_error():
+    with pytest.raises(ValueError):
+
+        class MyDevice(Device, skip=True):
+            @Device.task
+            def foo():
+                pass
+
+            @Device.task(implementation="circuitpython")
+            def foo():  # noqa: F811
+                pass


### PR DESCRIPTION
# Features
* Allows for implementation-specific decorators by specifying`implementation="implementation name"` in executer decorators.
  Example:
  ```
      class MyDevice(Device, skip=True):
        @Device.task(implementation="micropython")
        def test_task():
            return "micropython_task_return_value"

        @Device.task(implementation="circuitpython")
        def test_task():  # noqa: F811
            return "circuitpython_task_return_value"
  ```
* Add support for executers defined in mixin classes. If the mixin provided methods are to be overloaded, the mixin class must use the `DeviceMeta` metaclass.

# Misc
* Broke up the large `device.py` module into several modules.