### PR TITLE
Modify MRO order, add ignore_errors=False to global executers.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Run tests
         run: |
           source ${{ env.ACTIVATE_PYTHON_VENV }}
-          python -m pytest --cov=belay --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml --max-runs=3 --timeout=120 --force-flaky --network tests tests/integration
+          python -m pytest --cov=belay --cov-report=term --cov-report=xml --cov-config=.coveragerc --junitxml=testresults.xml --network tests tests/integration
           coverage report
 
       - name: Upload coverage to Codecov

--- a/belay/device.py
+++ b/belay/device.py
@@ -589,6 +589,9 @@ class Device(metaclass=DeviceMeta):
             Automatically invokes decorated functions at the end of object ``__init__``.
             Methods will be executed in order-registered.
             Defaults to ``False``.
+        ignore_errors: bool
+            Discard any device-side uncaught exception.
+            Defaults to ``False``.
         implementation: str
             If supplied, the provided method will **only** be used if the board's implementation **name** matches.
             Several methods of the same name can be overloaded that support different implementations.
@@ -647,6 +650,9 @@ class Device(metaclass=DeviceMeta):
         record: bool
             Each invocation of the executer is recorded for playback upon reconnect.
             Defaults to ``True``.
+        ignore_errors: bool
+            Discard any device-side uncaught exception.
+            Defaults to ``False``.
         implementation: str
             If supplied, the provided method will **only** be used if the board's implementation **name** matches.
             Several methods of the same name can be overloaded that support different implementations.

--- a/belay/device_meta.py
+++ b/belay/device_meta.py
@@ -98,3 +98,22 @@ class DeviceMeta(RegistryMeta):
         }
         output_cls = super().__new__(cls, name, bases, overload_namespace, **kwargs)
         return output_cls
+
+    def mro(self):
+        mro = super().mro()
+        # Move ``Device`` to back, if it exists in the mro
+
+        try:
+            from belay.device import Device
+        except ImportError:  # circular import on first use
+            return mro
+
+        try:
+            mro.remove(Device)
+        except ValueError:  # Device was not in ``bases``
+            return mro
+
+        # Insert it right before ``object``
+        mro.insert(mro.index(object), Device)
+
+        return mro

--- a/belay/executers.py
+++ b/belay/executers.py
@@ -54,6 +54,7 @@ class _GlobalExecuter(Executer, skip=True):
         minify: bool = True,
         register: bool = True,
         record: bool = True,
+        ignore_errors: bool = False,
     ) -> Callable[[Callable[P, R]], Callable[P, R]]:
         ...
 
@@ -64,6 +65,7 @@ class _GlobalExecuter(Executer, skip=True):
         minify: bool = True,
         register: bool = True,
         record: bool = True,
+        ignore_errors: bool = False,
     ) -> Union[Callable[[Callable[P, R]], Callable[P, R]], Callable[P, R]]:
         if f is None:
             return wraps_partial(self, minify=minify, register=register, record=record)
@@ -88,9 +90,13 @@ class _GlobalExecuter(Executer, skip=True):
             if arg_assign_cmd:
                 cmd = arg_assign_cmd + "\n" + cmd
 
-            return self._belay_device._traceback_execute(
-                src_file, src_lineno, name, cmd, record=record
-            )
+            try:
+                self._belay_device._traceback_execute(
+                    src_file, src_lineno, name, cmd, record=record
+                )
+            except Exception:
+                if not ignore_errors:
+                    raise
 
         if register:
             setattr(self, name, executer)

--- a/belay/pyboard.py
+++ b/belay/pyboard.py
@@ -211,6 +211,9 @@ class ProcessToSerial:
 
         atexit.register(self.close)
 
+        while b">>>" not in self.buf:
+            time.sleep(0.0001)
+
     def close(self):
         _kill_process(self.subp.pid)
         atexit.unregister(self.close)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ exclude_lines = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--import-mode=importlib"
+addopts = "--import-mode=importlib --max-runs=3 --timeout=120 --force-flaky --no-success-flaky-report"
 norecursedirs = "integration"
 markers = [
     "network: mark a test that requires network access.",

--- a/tests/integration/test_classes.py
+++ b/tests/integration/test_classes.py
@@ -123,6 +123,18 @@ def test_classes_teardown(emulate_command):
         device.teardown()  # Testing that it can be directly called
 
 
+def test_classes_teardown_ignore_error(emulate_command):
+    """Simply tests as its called and no uncaught exceptions occur."""
+
+    class MyDevice(Device, skip=True):
+        @Device.teardown(ignore_errors=True)
+        def teardown():
+            raise ValueError
+
+    with MyDevice(emulate_command):
+        pass
+
+
 def test_classes_teardown_mocked(emulate_command, mocker):
     """Tests if the teardown functions are executed on close."""
 

--- a/tests/integration/test_classes.py
+++ b/tests/integration/test_classes.py
@@ -179,11 +179,11 @@ def test_classes_executer_implementation_overload(emulate_command, mocker):
 
         @Device.teardown(implementation="micropython")
         def test_teardown():
-            return "micropython"
+            pass
 
         @Device.teardown(implementation="circuitpython")
         def test_teardown():  # noqa: F811
-            return "circuitpython"
+            pass
 
         @Device.task
         def get_setup_var():
@@ -278,6 +278,15 @@ def test_classes_executer_implementation_overload_mixins_per_implementation_stom
     """Tests if proper overloaded methods from mixins are executed depending on implementation.
 
     In this test, they have same names as executers.
+
+    The original bug was caused by having the mixins like:
+
+        class MyDevice(Device, MicropythonMixin, CircuitpythonMixin, skip=True):
+            pass
+
+    where ``setup`` was ``Device.setup`` due to MRO.
+
+    Fix: ``Device`` is now moved to end of MRO in ``belay.DeviceMeta.mro``.
     """
 
     class MicropythonMixin(metaclass=DeviceMeta):


### PR DESCRIPTION
# Changes
* In the case of device mixins, the `Device` class will automatically be moved to the end of the MRO. This makes name stomping of `setup` and `teardown` and other executers as expected.
* Add `ignore_errors=False` flag to global executers (`setup` and `teardown`). This is particularly useful for `teardown` since it may be invoked before the device is even fully setup.