### PR TITLE
Fix device.sync when tem dir drive and source dir drive are different.

### DIFF
--- a/belay/device_sync_support.py
+++ b/belay/device_sync_support.py
@@ -81,7 +81,7 @@ def preprocess_src_file(
     tmp_dir = Path(tmp_dir)
     src_file = Path(src_file)
 
-    transformed = tmp_dir / src_file.relative_to(tmp_dir.anchor) if src_file.is_absolute() else tmp_dir / src_file
+    transformed = tmp_dir / src_file.relative_to(src_dir.anchor) if src_file.is_absolute() else tmp_dir / src_file
     transformed.parent.mkdir(parents=True, exist_ok=True)
 
     if src_file.suffix == ".py":


### PR DESCRIPTION
There was a bug in device.sync that only shows up when the drive that the source code is in is different from the drive the temp folder is on.

I believe the intention was to get the path of the source file by geting the relative path to the source file from the source file anchor , which I think in this case is the drive letter.

However the code was trying to get the anchor of the temp file rather than the source file, which when both were on the same drive, wasn't a problem.