### PR TITLE
Fix bug in device.sync that prevented it from working on some drives

### DIFF
--- a/belay/device_sync_support.py
+++ b/belay/device_sync_support.py
@@ -81,7 +81,7 @@ def preprocess_src_file(
     tmp_dir = Path(tmp_dir)
     src_file = Path(src_file)
 
-    transformed = tmp_dir / src_file.relative_to(tmp_dir.anchor) if src_file.is_absolute() else tmp_dir / src_file
+    transformed = tmp_dir / src_file.relative_to(src_dir.anchor) if src_file.is_absolute() else tmp_dir / src_file
     transformed.parent.mkdir(parents=True, exist_ok=True)
 
     if src_file.suffix == ".py":

--- a/belay/device_sync_support.py
+++ b/belay/device_sync_support.py
@@ -81,7 +81,7 @@ def preprocess_src_file(
     tmp_dir = Path(tmp_dir)
     src_file = Path(src_file)
 
-    transformed = tmp_dir / src_file.relative_to(src_dir.anchor) if src_file.is_absolute() else tmp_dir / src_file
+    transformed = tmp_dir / src_file.relative_to(src_file.anchor) if src_file.is_absolute() else tmp_dir / src_file
     transformed.parent.mkdir(parents=True, exist_ok=True)
 
     if src_file.suffix == ".py":

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -447,9 +447,9 @@ def test_preprocess_src_file_cross_mpy_absolute(mocker):
     call = mock_check_output.call_args_list[0][0][0]
     assert call[0] == "fake-mpy-cross-binary"
     assert call[1] == "-o"
-    assert call[2].as_posix() == "C:/tmp/abc123/foo/bar/baz.py"
+    assert call[2].as_posix() == "C:/tmp/abc123/foo/bar/baz.mpy"
     assert call[3].as_posix() == "D:/foo/bar/baz.py"
-    assert actual.as_posix() == "C:/tmp/abc123/foo/bar/baz.py"
+    assert actual.as_posix() == "C:/tmp/abc123/foo/bar/baz.mpy"
 
 
 def test_preprocess_src_file_default_generic(tmp_path):

--- a/tests/test_device_sync.py
+++ b/tests/test_device_sync.py
@@ -417,7 +417,7 @@ def test_preprocess_src_file_default_py(tmp_path):
     assert actual == Path("foo/bar/baz.py")
 
 
-def test_preprocess_src_file_cross_mpy(tmp_path, mocker):
+def test_preprocess_src_file_cross_mpy_relative(tmp_path, mocker):
     mock_check_output = mocker.patch("belay.device_sync_support.subprocess.check_output")
     actual = device_sync_support.preprocess_src_file(
         tmp_path,
@@ -432,6 +432,24 @@ def test_preprocess_src_file_cross_mpy(tmp_path, mocker):
     assert call[2].as_posix().endswith("foo/bar/baz.mpy")
     assert call[3].as_posix().endswith("foo/bar/baz.py")
     assert actual.as_posix().endswith("foo/bar/baz.mpy")
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Runs only on Windows")
+def test_preprocess_src_file_cross_mpy_absolute(mocker):
+    mock_check_output = mocker.patch("belay.device_sync_support.subprocess.check_output")
+    actual = device_sync_support.preprocess_src_file(
+        "C:/tmp/abc123",
+        "D:/foo/bar/baz.py",
+        False,
+        "fake-mpy-cross-binary",
+    )
+    mock_check_output.assert_called_once()
+    call = mock_check_output.call_args_list[0][0][0]
+    assert call[0] == "fake-mpy-cross-binary"
+    assert call[1] == "-o"
+    assert call[2].as_posix() == "C:/tmp/abc123/foo/bar/baz.py"
+    assert call[3].as_posix() == "D:/foo/bar/baz.py"
+    assert actual.as_posix() == "C:/tmp/abc123/foo/bar/baz.py"
 
 
 def test_preprocess_src_file_default_generic(tmp_path):


### PR DESCRIPTION
device.sync wasn't working when the source folder was on a different drive than the temp directory.

I think the intention of the code was to get the path without the drive specifier by getting the relative path of it when compared to the drive specifier. However the temp file driver specifier was being passed through rather than the source file one.