### PR TITLE
Documentation note that sync deletes all other files on device.

### DIFF
--- a/docs/source/Quick Start.rst
+++ b/docs/source/Quick Start.rst
@@ -140,6 +140,8 @@ For more complicated hardware interactions, additional python modules/files need
 ``sync`` takes in a path to a local folder.
 The contents of the folder will be synced to the device's root directory.
 
+**NOTE:** This will delete any existing files currently on device before syncing.
+
 For example, if the local filesystem looks like:
 
 ::


### PR DESCRIPTION
I hadn't realized when I ran sync that it would delete all the other files on my device, so I figure it's worth making it clear, especially as a common way of using Thonny is actually to do development directly on the device files, and periodically backup, which is what I had been doing. Luckily I had a recent backup.