### PR TITLE
Fix warning due to using PydanticV2

### DIFF
--- a/belay/packagemanager/models.py
+++ b/belay/packagemanager/models.py
@@ -14,7 +14,7 @@ prevalidator_reuse = partial(validator_reuse, pre=True)
 
 class BaseModel(PydanticBaseModel):
     class Config:
-        allow_mutation = False
+        frozen = True
 
 
 class DependencySourceConfig(BaseModel):


### PR DESCRIPTION
According to
https://docs.pydantic.dev/2.0/migration/#changes-to-pydanticfieldm, The `allow_mutation` property of `Field` is now called `frozen`.