### PR TITLE
Introduce 'trusted' keyword to task decorator for allowing arbitrary response execution.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ ignore = [
     "E501",
     "F401",
     "TRY003",  # Avoid specifying messages outside exception class; overly strict, especially for ValueError
+    "SIM108",  # Encourages ternary operator
 ]
 line-length = 120  # Must agree with Black
 

--- a/tests/integration/test_function_decorators.py
+++ b/tests/integration/test_function_decorators.py
@@ -27,6 +27,16 @@ def test_task_basic(emulated_device, mocker):
     spy_parse_belay_response.assert_called_once_with("_BELAYR10\r\n")
 
 
+def test_task_basic_trusted(emulated_device, mocker):
+    @emulated_device.task(trusted=True)
+    def foo():
+        return bytearray(b"\x01")
+
+    res = foo()
+    assert isinstance(res, bytearray)
+    assert res == bytearray(b"\x01")
+
+
 def test_task_generators_basic(emulated_device, mocker):
     spy_parse_belay_response = mocker.spy(belay.device, "parse_belay_response")
 


### PR DESCRIPTION
Addresses #148 . @pdietl can you give this a test? Is the API documentation sufficient?