### PR TITLE
use pypi importlib_resources for <3.9

### DIFF
--- a/belay/cli/new.py
+++ b/belay/cli/new.py
@@ -1,17 +1,22 @@
-import importlib.resources as pkg_resources
 import re
 import shutil
+import sys
 from pathlib import Path
 
 from packaging.utils import canonicalize_name
 from typer import Argument, Option
+
+if sys.version_info < (3, 9, 0):
+    import importlib_resources
+else:
+    import importlib.resources as importlib_resources
 
 
 def new(project_name: str = Argument(..., help="Project Name.")):
     """Create a new micropython project structure."""
     package_name = canonicalize_name(project_name)
     dst_dir = Path() / project_name
-    template_dir = pkg_resources.files("belay") / "cli" / "new_template"
+    template_dir = importlib_resources.files("belay") / "cli" / "new_template"
 
     shutil.copytree(str(template_dir), str(dst_dir))
 

--- a/belay/device.py
+++ b/belay/device.py
@@ -2,7 +2,6 @@ import ast
 import atexit
 import concurrent.futures
 import contextlib
-import importlib.resources
 import linecache
 import re
 import shutil
@@ -45,6 +44,11 @@ from .inspect import isexpression
 from .pyboard import Pyboard, PyboardError, PyboardException
 from .typing import BelayReturn, PathType
 from .webrepl import WebreplToSerial
+
+if sys.version_info < (3, 9, 0):
+    import importlib_resources
+else:
+    import importlib.resources as importlib_resources
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -495,11 +499,11 @@ class Device(metaclass=DeviceMeta):
         **kwargs
             Passed along to ``Device.sync``.
         """
-        pkg_files = importlib.resources.files(package)
+        pkg_files = importlib_resources.files(package)
         with TemporaryDirectory() as tmp_dir:
             tmp_dir = Path(tmp_dir)
             for subfolder in subfolders:
-                with importlib.resources.as_file(pkg_files / str(subfolder)) as f:
+                with importlib_resources.as_file(pkg_files / str(subfolder)) as f:
                     shutil.copytree(f, tmp_dir, dirs_exist_ok=True)
             self.sync(tmp_dir, dst=dst, **kwargs)
 

--- a/belay/helpers.py
+++ b/belay/helpers.py
@@ -1,9 +1,14 @@
-import importlib.resources
 import secrets
 import string
+import sys
 from functools import lru_cache, partial, wraps
 
 from . import snippets
+
+if sys.version_info < (3, 9, 0):
+    import importlib_resources
+else:
+    import importlib.resources as importlib_resources
 
 _python_identifier_chars = string.ascii_uppercase + string.ascii_lowercase + string.digits
 
@@ -20,4 +25,4 @@ def random_python_identifier(n=16):
 @lru_cache
 def read_snippet(name):
     resource = f"{name}.py"
-    return importlib.resources.files(snippets).joinpath(resource).read_text()
+    return importlib_resources.files(snippets).joinpath(resource).read_text()


### PR DESCRIPTION
Addresses #155 

This was originally supposed to be addressed in https://github.com/BrianPugh/belay/commit/344d04ebed8d7a41d73fe4aac732f6cf02b276cb

Before I merge, I need to figure out why CI didn't catch this.