### PR TITLE
fix "belay new" CLI command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.0.284"
+    rev: "v0.5.1"
     hooks:
       - id: ruff
         args: []
         exclude: ^(belay/snippets/)
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.4.2
     hooks:
       - id: black
         args:
@@ -20,13 +20,13 @@ repos:
         exclude: ^(belay/snippets/)
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.15.0
+    rev: 1.18.0
     hooks:
       - id: blacken-docs
         exclude: ^(docs/source/How Belay Works.rst)
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -53,20 +53,12 @@ repos:
         exclude: \.(html|svg)$
 
   - repo: https://github.com/fredrikaverpil/creosote.git
-    rev: v2.6.3
+    rev: v3.0.2
     hooks:
       - id: creosote
-        args:
-          - "--venv=.venv"
-          - "--paths=belay"
-          - "--deps-file=pyproject.toml"
-          - "--sections=tool.poetry.dependencies"
-          - "--exclude-deps"
-          - "importlib_resources"
-          - "pydantic"
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.3.0
     hooks:
       - id: codespell
         exclude: ^(poetry.lock)

--- a/belay/cli/new.py
+++ b/belay/cli/new.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 from packaging.utils import canonicalize_name
-from typer import Argument, Option
+from typer import Argument
 
 if sys.version_info < (3, 9, 0):
     import importlib_resources
@@ -18,7 +18,7 @@ def new(project_name: str = Argument(..., help="Project Name.")):
     dst_dir = Path() / project_name
     template_dir = importlib_resources.files("belay") / "cli" / "new_template"
 
-    shutil.copytree(str(template_dir), str(dst_dir))
+    shutil.copytree(str(template_dir), str(dst_dir), ignore=shutil.ignore_patterns("*.pyc", "__pycache__"))
 
     # Find/Replace Engine
     replacements: dict[str, str] = {
@@ -33,7 +33,8 @@ def new(project_name: str = Argument(..., help="Project Name.")):
         def _replace(match):
             return replacements[match.group(0)]
 
-        return re.sub("|".join(r"\b%s\b" % re.escape(s) for s in replacements), _replace, string)
+        pattern = "|".join(rf"\b{re.escape(s)}\b" if " " not in s else re.escape(s) for s in replacements)
+        return re.sub(pattern, _replace, string)
 
     for path in paths:
         if path.is_dir():

--- a/belay/device.py
+++ b/belay/device.py
@@ -562,15 +562,13 @@ class Device(metaclass=DeviceMeta):
 
     @overload
     @staticmethod
-    def setup(f: Callable[P, R]) -> Callable[P, R]:
-        ...
+    def setup(f: Callable[P, R]) -> Callable[P, R]: ...
 
     @overload
     @staticmethod
     def setup(
         *, autoinit: bool = False, implementation: str = "", **kwargs
-    ) -> Callable[[Callable[P, R]], Callable[P, R]]:
-        ...
+    ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
     @staticmethod
     def setup(
@@ -626,13 +624,11 @@ class Device(metaclass=DeviceMeta):
 
     @overload
     @staticmethod
-    def teardown(f: Callable[P, R]) -> Callable[P, R]:
-        ...
+    def teardown(f: Callable[P, R]) -> Callable[P, R]: ...
 
     @overload
     @staticmethod
-    def teardown(*, implementation: str = "", **kwargs) -> Callable[[Callable[P, R]], Callable[P, R]]:
-        ...
+    def teardown(*, implementation: str = "", **kwargs) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
     @staticmethod
     def teardown(
@@ -677,13 +673,11 @@ class Device(metaclass=DeviceMeta):
 
     @overload
     @staticmethod
-    def task(f: Callable[P, R]) -> Callable[P, R]:
-        ...
+    def task(f: Callable[P, R]) -> Callable[P, R]: ...
 
     @overload
     @staticmethod
-    def task(*, implementation: str = "", **kwargs) -> Callable[[Callable[P, R]], Callable[P, R]]:
-        ...
+    def task(*, implementation: str = "", **kwargs) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
     @staticmethod
     def task(
@@ -731,13 +725,11 @@ class Device(metaclass=DeviceMeta):
 
     @overload
     @staticmethod
-    def thread(f: Callable[P, R]) -> Callable[P, R]:
-        ...
+    def thread(f: Callable[P, R]) -> Callable[P, R]: ...
 
     @overload
     @staticmethod
-    def thread(*, implementation: str = "", **kwargs) -> Callable[[Callable[P, R]], Callable[P, R]]:
-        ...
+    def thread(*, implementation: str = "", **kwargs) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
     @staticmethod
     def thread(

--- a/belay/device_meta.py
+++ b/belay/device_meta.py
@@ -4,6 +4,7 @@ Inspired by mCoding example::
 
     https://github.com/mCodingLLC/VideosSampleCode/blob/master/videos/077_metaclasses_in_python/overloading.py
 """
+
 from autoregistry import RegistryMeta
 
 from .exceptions import NoMatchingExecuterError

--- a/belay/executers.py
+++ b/belay/executers.py
@@ -38,8 +38,7 @@ class Executer(Registry, suffix="Executer"):
 
 class _GlobalExecuter(Executer, skip=True):
     @overload
-    def __call__(self, f: Callable[P, R]) -> Callable[P, R]:
-        ...
+    def __call__(self, f: Callable[P, R]) -> Callable[P, R]: ...
 
     @overload
     def __call__(
@@ -49,8 +48,7 @@ class _GlobalExecuter(Executer, skip=True):
         register: bool = True,
         record: bool = True,
         ignore_errors: bool = False,
-    ) -> Callable[[Callable[P, R]], Callable[P, R]]:
-        ...
+    ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
     def __call__(
         self,
@@ -103,8 +101,7 @@ class TeardownExecuter(_GlobalExecuter):
 
 class TaskExecuter(Executer):
     @overload
-    def __call__(self, f: Callable[P, R]) -> Callable[P, R]:
-        ...
+    def __call__(self, f: Callable[P, R]) -> Callable[P, R]: ...
 
     @overload
     def __call__(
@@ -114,8 +111,7 @@ class TaskExecuter(Executer):
         register: bool = True,
         record: bool = False,
         trusted: bool = False,
-    ) -> Callable[[Callable[P, R]], Callable[P, R]]:
-        ...
+    ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
     def __call__(
         self,
@@ -185,8 +181,7 @@ class TaskExecuter(Executer):
 
 class ThreadExecuter(Executer):
     @overload
-    def __call__(self, f: Callable[P, R]) -> Callable[P, R]:
-        ...
+    def __call__(self, f: Callable[P, R]) -> Callable[P, R]: ...
 
     @overload
     def __call__(
@@ -195,8 +190,7 @@ class ThreadExecuter(Executer):
         minify: bool = True,
         register: bool = True,
         record: bool = True,
-    ) -> Callable[[Callable[P, R]], Callable[P, R]]:
-        ...
+    ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
     def __call__(
         self,

--- a/belay/webrepl.py
+++ b/belay/webrepl.py
@@ -23,6 +23,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
+
 import errno
 import socket
 import struct
@@ -95,10 +96,10 @@ class Websocket:
                     break
                 if text_ok and fl == 0x81:
                     break
-                debugmsg("Got unexpected websocket record of type %x, skipping it" % fl)
+                debugmsg(f"Got unexpected websocket record of type {fl:x}, skipping it")
                 while sz:
                     skip = self.s.recv(sz)
-                    debugmsg("Skip data: %s" % skip)
+                    debugmsg(f"Skip data: {skip}")
                     sz -= len(skip)
             data = self.recvexactly(sz)
             if len(data) != sz:
@@ -203,14 +204,14 @@ def get_file(ws, local_file, remote_file):
 
 def help(rc=0):
     exename = sys.argv[0].rsplit("/", 1)[-1]
-    print("%s - Perform remote file operations using MicroPython WebREPL protocol" % exename)
+    print(f"{exename} - Perform remote file operations using MicroPython WebREPL protocol")
     print("Arguments:")
     print("  [-p password] <host>:<remote_file> <local_file> - Copy remote file to local file")
     print("  [-p password] <local_file> <host>:<remote_file> - Copy local file to remote file")
     print("Examples:")
-    print("  %s script.py 192.168.4.1:/another_name.py" % exename)
-    print("  %s script.py 192.168.4.1:/app/" % exename)
-    print("  %s -p password 192.168.4.1:/app/script.py ." % exename)
+    print(f"  {exename} script.py 192.168.4.1:/another_name.py")
+    print(f"  {exename} script.py 192.168.4.1:/app/")
+    print(f"  {exename} -p password 192.168.4.1:/app/script.py .")
     sys.exit(rc)
 
 
@@ -297,8 +298,8 @@ class WebreplToSerial:
         if self.ws is None:
             raise WebsocketClosedError
 
-        readin = self.ws.read(size, text_ok=True, size_match=False)
-        self.fifo.extend(readin)
+        read_in = self.ws.read(size, text_ok=True, size_match=False)
+        self.fifo.extend(read_in)
 
         data = b""
         while len(data) < size and len(self.fifo) > 0:

--- a/docs/source/Package Manager.rst
+++ b/docs/source/Package Manager.rst
@@ -232,7 +232,7 @@ This is not a true virtual environment; currently the ``micropython`` binary mus
 
 clean
 -----
-Removes any previously downloaded dependencies no longer specified in ``tool.belay.dependecies``.
+Removes any previously downloaded dependencies no longer specified in ``tool.belay.dependencies``.
 
 .. code-block:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,25 +105,7 @@ markers = [
 
 [tool.ruff]
 target-version = 'py38'
-select = [
-    "B",  # flake8-bugbear
-    "C4", # flake8-comprehensions
-    "D",  # pydocstyle
-    "E",  # Error
-    "F",  # pyflakes
-    "I",  # isort
-    "ISC", # flake8-implicit-str-concat
-    "N",  # pep8-naming
-    "PGH",  # pygrep-hooks
-    "PTH", # flake8-use-pathlib
-    "Q",  # flake8-quotes
-    "SIM",  # flake8-simplify
-    "TRY",  # tryceratops
-    "UP",  # pyupgrade
-    "W",  # Warning
-    "YTT", # flake8-2020
-]
-
+line-length = 120  # Must agree with Black
 exclude = [
     "migrations",
     "__pycache__",
@@ -139,6 +121,7 @@ exclude = [
     "tests/integration/test_function_decorators_exception.py",
 ]
 
+[tool.ruff.lint]
 ignore = [
     "B905",  # zip strict=True; remove once python <3.10 support is dropped.
     "D100",
@@ -157,19 +140,37 @@ ignore = [
     "TRY003",  # Avoid specifying messages outside exception class; overly strict, especially for ValueError
     "SIM108",  # Encourages ternary operator
 ]
-line-length = 120  # Must agree with Black
 
-[tool.ruff.flake8-bugbear]
+select = [
+    "B",  # flake8-bugbear
+    "C4", # flake8-comprehensions
+    "D",  # pydocstyle
+    "E",  # Error
+    "F",  # pyflakes
+    "I",  # isort
+    "N",  # pep8-naming
+    "PGH",  # pygrep-hooks
+    "PTH", # flake8-use-pathlib
+    "Q",  # flake8-quotes
+    "SIM",  # flake8-simplify
+    "TRY",  # tryceratops
+    "UP",  # pyupgrade
+    "W",  # Warning
+    "YTT", # flake8-2020
+]
+
+
+[tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = [
     "chr",
     "typer.Argument",
     "typer.Option",
 ]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [
     "D100",
     "D101",
@@ -186,7 +187,7 @@ convention = "numpy"
     "F841"
 ]
 
-[tool.ruff.pep8-naming]
+[tool.ruff.lint.pep8-naming]
 staticmethod-decorators = [
     "belay.Device.setup",
     "belay.Device.task",
@@ -194,4 +195,14 @@ staticmethod-decorators = [
     "belay.Device.thread",
     "pydantic.validator",
     "pydantic.root_validator",
+]
+
+[tool.creosote]
+venvs=[".venv"]
+paths=["belay"]
+deps-file="pyproject.toml"
+sections=["tool.poetry.dependencies"]
+exclude-deps =[
+  "importlib_resources",
+  "pydantic",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,15 +65,17 @@ def cli_runner(mock_device):
 
 
 @pytest.fixture(
-    params=[
-        "micropython-v1.17.uf2",
-    ]
-    if env_parse_bool("BELAY_SHORT_INTEGRATION_TEST")
-    else [
-        "micropython-v1.17.uf2",
-        "circuitpython-v7.3.3.uf2",
-        "circuitpython-v8.0.0.uf2",
-    ]
+    params=(
+        [
+            "micropython-v1.17.uf2",
+        ]
+        if env_parse_bool("BELAY_SHORT_INTEGRATION_TEST")
+        else [
+            "micropython-v1.17.uf2",
+            "circuitpython-v7.3.3.uf2",
+            "circuitpython-v8.0.0.uf2",
+        ]
+    )
 )
 def emulate_command(request):
     return f"exec:npm run --prefix rp2040js start:micropython -- --image={request.param}"

--- a/tests/integration/test_function_decorators.py
+++ b/tests/integration/test_function_decorators.py
@@ -11,7 +11,7 @@ def test_setup_basic(emulated_device):
 
     setup({"bar": 25})
 
-    assert {"bar": 25} == emulated_device("config")
+    assert emulated_device("config") == {"bar": 25}
     assert emulated_device("foo") == 25
 
 
@@ -79,7 +79,7 @@ def test_task_generators_communicate(emulated_device):
     actual.append(generator.send(25))
     with pytest.raises(StopIteration):
         generator.send(50)
-    assert [5, 25] == actual
+    assert actual == [5, 25]
 
 
 def test_teardown(emulated_device, mocker):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -114,7 +114,7 @@ def test_parse_belay_response_stop_iteration():
 
 
 def test_parse_belay_response_r():
-    assert [1, 2, 3] == belay.device.parse_belay_response("_BELAYR[1,2,3]")
+    assert belay.device.parse_belay_response("_BELAYR[1,2,3]") == [1, 2, 3]
     assert belay.device.parse_belay_response("_BELAYR1") == 1
     assert belay.device.parse_belay_response("_BELAYR1.23") == 1.23
     assert belay.device.parse_belay_response("_BELAYR'a'") == "a"

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -4,7 +4,6 @@ Note: ``untokenize`` doesn't properly preserve inter-token spacing, so this test
 may need to change while still remaining valid.
 """
 
-
 import types
 import pytest
 


### PR DESCRIPTION
Previously the `belay new` CLI command was broken in some installed because there would be a `__pycache__` directory in the template directory. These files are now ignored.