### PR TITLE
`dedent` all cmds in `Device.__call__`

### DIFF
--- a/belay/device.py
+++ b/belay/device.py
@@ -9,6 +9,7 @@ import sys
 from inspect import signature
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from textwrap import dedent
 from types import ModuleType
 from typing import Any, Callable, Optional, TextIO, TypeVar, Union, overload
 
@@ -301,6 +302,8 @@ class Device(metaclass=DeviceMeta):
         -------
             Correctly interpreted return value from executing code on-device.
         """
+        cmd = dedent(cmd)
+
         if minify:
             cmd = minify_code(cmd)
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -89,7 +89,7 @@ def test_device_traceback_execute(mocker, mock_device, tmp_path):
 
     src_lineno = 2
     name = "foo"
-    cmd = None  # Doesn't matter; mocked
+    cmd = ""  # Doesn't matter; mocked
     expected_msg = (
         "Traceback (most recent call last):\r\n"
         '  File "<stdin>", line 1, in <module>\r\n'


### PR DESCRIPTION
@kc64 what do you think of this? I think the only reason I didn't originally dedent before was I didn't know it existed when I originally implemented Belay 😄 .

If someone in the future has issues with this, we can add a `dedent: bool = True` argument to `Device.__call__`, but I don't foresee a real use-case that requires this.