### PR TITLE
Add missing setup() call in circuitpython blink example

### DIFF
--- a/examples/01_blink_led/circuitpython.py
+++ b/examples/01_blink_led/circuitpython.py
@@ -29,6 +29,7 @@ def set_led(state):
     print(f"Printing from device; turning LED to {state}.")
     led.value = state
 
+setup()
 
 while True:
     set_led(True)


### PR DESCRIPTION
The setup() call was missing in the circuitpython blink example.

This resulted in:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".\belay led blink test circuitpython.py", line 35, in set_led
    led.value = state
NameError: name 'led' is not defined
```