### PR TITLE
BUGFIX: fix removal of str if it begins an expression when minifying.

### DIFF
--- a/belay/_minify.py
+++ b/belay/_minify.py
@@ -1,7 +1,7 @@
 import tokenize
 from collections import deque
 from io import StringIO
-from tokenize import COMMENT, DEDENT, INDENT, NEWLINE, OP, STRING
+from tokenize import COMMENT, DEDENT, INDENT, NAME, NEWLINE, OP, STRING
 
 _token_type_line_start = {NEWLINE, DEDENT, INDENT}
 
@@ -36,13 +36,14 @@ def minify(code: str) -> str:
     prev_token_types = deque([INDENT], maxlen=2)
     container_level = 0
 
-    for (
+    tokens = list(tokenize.generate_tokens(StringIO(code).readline))
+    for i, (
         token_type,
         string,
         (start_line, start_col),
         (end_line, end_col),
         _,
-    ) in tokenize.generate_tokens(StringIO(code).readline):
+    ) in enumerate(tokens):
         prev_token_types.append(token_type)
         prev_token_type = prev_token_types.popleft()
 
@@ -72,8 +73,18 @@ def minify(code: str) -> str:
             and container_level == 0
             and (prev_token_type in (NEWLINE, INDENT) or start_col == global_start_col)
         ):
-            # Docstring
-            out.append(" " * level + "0" + "\n" * string.count("\n"))
+            # Probably a docstring
+            remove_docstring = True
+            try:
+                if tokens[i + 1].type == NAME:
+                    # prevents removing initial string in an expression like ``'b' in foo``
+                    remove_docstring = False
+            except IndexError:
+                pass
+            if remove_docstring:
+                out.append(" " * level + "0" + "\n" * string.count("\n"))
+            else:
+                out.append(string)
         elif start_line > prev_start_line and token_type != NEWLINE:
             # First op of a line, needs its minimized indent
             out.append(" " * level)  # Leading indent

--- a/tests/test_minify.py
+++ b/tests/test_minify.py
@@ -158,3 +158,8 @@ print('l4',l4)
 print('l5',l5)
 """
     assert res == expected
+
+
+def test_minify_leading_string_expression():
+    res = minify("'b' in foo")
+    assert res == "'b' in foo"


### PR DESCRIPTION
Minifying would break expressions that started with a string, like `"a" in {'a', 'b', 'c'}`. This fixes that.