### PR TITLE
Verify files use encoding utf8

### DIFF
--- a/belay/packagemanager/group.py
+++ b/belay/packagemanager/group.py
@@ -153,7 +153,7 @@ def _verify_files(path: PathType):
 
     for f in gen:
         if f.suffix == ".py":
-            code = f.read_text()
+            code = f.read_text(encoding="utf-8")
             ast.parse(code)
 
 


### PR DESCRIPTION
I have had issues on windows with some micro python repos. Using utf-8 should be the default I think. 

https://peps.python.org/pep-0686/