### PR TITLE
micropython package support

### DIFF
--- a/belay/exceptions.py
+++ b/belay/exceptions.py
@@ -51,3 +51,11 @@ class NotBelayResponseError(BelayException):
 
 class NoMatchingExecuterError(BelayException):
     """No valid executer found for the given board Implementation."""
+
+
+class PackageNotFoundError(BelayException):
+    """Package could not be found in index or URL."""
+
+
+class IntegrityError(BelayException):
+    """File integrity verification failed (hash mismatch)."""

--- a/belay/packagemanager/downloaders/__init__.py
+++ b/belay/packagemanager/downloaders/__init__.py
@@ -1,2 +1,26 @@
-from ._github import github
-from .common import NonMatchingURI, download_uri, downloaders
+# isort: skip_file
+# Import order matters: GitProviderUrl must be imported before subclasses
+from .common import (
+    NonMatchingURI,
+    download_uri,
+)
+from .git import (
+    GitProviderUrl,
+    InvalidGitUrlError,
+    rewrite_url,
+)
+
+# Import subclasses to register them with the Registry.
+# These must be imported AFTER GitProviderUrl to ensure proper registration.
+from ._github import GitHubUrl
+from ._gitlab import GitLabUrl
+
+__all__ = [
+    "GitHubUrl",
+    "GitLabUrl",
+    "GitProviderUrl",
+    "InvalidGitUrlError",
+    "NonMatchingURI",
+    "download_uri",
+    "rewrite_url",
+]

--- a/belay/packagemanager/downloaders/_gitlab.py
+++ b/belay/packagemanager/downloaders/_gitlab.py
@@ -1,0 +1,28 @@
+"""GitLab URL handling for package downloads."""
+
+import re
+from dataclasses import dataclass
+
+from belay.packagemanager.downloaders.git import GitProviderUrl
+
+
+@dataclass
+class GitLabUrl(GitProviderUrl):
+    """Parsed GitLab URL (shorthand or full HTTPS)."""
+
+    # Patterns for full HTTPS URLs
+    https_patterns = (
+        re.compile(r"gitlab\.com/(.+?)/(.+?)/-/raw/(.+?)/(.*)"),  # raw
+        re.compile(r"gitlab\.com/(.+?)/(.+?)/-/blob/(.+?)/(.*)"),  # blob view
+        re.compile(r"gitlab\.com/(.+?)/(.+?)/-/tree/(.+?)/(.*)"),  # tree view
+    )
+
+    @property
+    def scheme(self) -> str:
+        return "gitlab"
+
+    @property
+    def raw_url(self) -> str:
+        """Raw content URL at gitlab.com."""
+        base = f"https://gitlab.com/{self.user}/{self.repo}/-/raw/{self.branch}"
+        return f"{base}/{self.path}" if self.path else base

--- a/belay/packagemanager/downloaders/_package_json.py
+++ b/belay/packagemanager/downloaders/_package_json.py
@@ -1,0 +1,220 @@
+"""Downloader for MicroPython package.json packages.
+
+This module handles downloading packages that use the MicroPython package.json
+format, including packages from the micropython.org index and GitHub/GitLab
+repositories.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from belay.exceptions import IntegrityError, PackageNotFoundError
+from belay.packagemanager.downloaders._retry import fetch_url
+from belay.packagemanager.downloaders.common import NonMatchingURI
+from belay.packagemanager.downloaders.git import GitProviderUrl, InvalidGitUrlError
+from belay.packagemanager.package_json import (
+    DEFAULT_MPY_VERSION,
+    DEFAULT_PACKAGE_INDICES,
+    compute_micropython_hash,
+)
+from belay.packagemanager.resolver import resolve_dependencies
+
+
+def _is_plain_package_name(name: str) -> bool:
+    """Check if string looks like a plain package name (not a URL or path).
+
+    Plain package names:
+    - Contain only alphanumeric characters, underscores, and hyphens
+    - Don't contain path separators or URL schemes
+    - Don't have file extensions
+
+    Parameters
+    ----------
+    name
+        String to check.
+
+    Returns
+    -------
+    bool
+        True if string looks like a plain package name.
+    """
+    if not name:
+        return False
+
+    # Check for URL schemes or path indicators
+    if ":" in name or "/" in name or "\\" in name:
+        return False
+
+    # Check for file extensions (common ones that would indicate a file, not a package)
+    if "." in name:
+        return False
+
+    # Check characters are valid for package names
+    # MicroPython packages use alphanumeric, underscores, and hyphens
+    return all(c.isalnum() or c in "_-" for c in name)
+
+
+def _is_package_json_uri(uri: str) -> bool:
+    """Determine if URI should be handled as package.json.
+
+    Detection logic:
+    - Plain package names (e.g., "aiohttp") -> index lookup
+    - Explicit mip: prefix (e.g., "mip:aiohttp") -> index lookup
+    - Explicit .json URLs -> package.json
+    - github:org/repo (no file path) -> package.json at root
+    - github:org/repo/package.json or .json suffix -> explicit package.json
+    - github:org/repo/file.py -> NOT package.json (single file)
+    - gitlab: same patterns as github:
+
+    Parameters
+    ----------
+    uri
+        URI to check.
+
+    Returns
+    -------
+    bool
+        True if this URI should be handled as a package.json reference.
+    """
+    # Extract version suffix if present (e.g., "github:user/repo@v1.0", "aiohttp@1.0")
+    base_uri = uri.split("@")[0] if "@" in uri and not uri.startswith(("http://", "https://")) else uri
+
+    # Plain package name (e.g., "aiohttp", "ntptime", "micropython-lib")
+    if _is_plain_package_name(base_uri):
+        return True
+
+    # Explicit .json URL
+    if base_uri.endswith(".json"):
+        return True
+
+    # Explicit MicroPython index prefix (mip:package_name)
+    if base_uri.startswith("mip:"):
+        return True
+
+    # github:/gitlab: shorthand (MicroPython package.json convention)
+    try:
+        parsed = GitProviderUrl.parse(uri)
+        # No path -> package.json at root
+        # Path with no file extension -> directory, assume package.json
+        # Path ending in .json -> explicit package.json
+        # Path with non-.json extension -> single file, NOT package.json
+        if not parsed.path:
+            return True
+        return not parsed.has_file_extension() or parsed.path.endswith(".json")
+    except InvalidGitUrlError:
+        return False
+
+
+def download_package_json(
+    dst: Path,
+    uri: str,
+    indices: Optional[list[str]] = None,
+    mpy_version: str = DEFAULT_MPY_VERSION,
+) -> Path:
+    """Download a MicroPython package.json-based package.
+
+    This downloader handles:
+    - MicroPython index packages (e.g., "mip:aiohttp", "mip:ntptime@1.0.0")
+    - GitHub repositories (e.g., "github:user/repo", "github:user/repo@tag")
+    - GitLab repositories (e.g., "gitlab:user/repo")
+    - Explicit package.json URLs
+
+    Parameters
+    ----------
+    dst
+        Destination directory for downloaded files.
+    uri
+        Package name or URL.
+    indices
+        Package index URL(s) for name-based lookups. If None, uses DEFAULT_PACKAGE_INDICES.
+    mpy_version
+        MicroPython version for index lookups ("py" for pure Python,
+        "6" for .mpy format version 6, etc.).
+
+    Returns
+    -------
+    Path
+        Destination directory.
+
+    Raises
+    ------
+    NonMatchingURI
+        If URI is not a package.json reference.
+    PackageNotFoundError
+        If package cannot be found or downloaded.
+    """
+    if not _is_package_json_uri(uri):
+        raise NonMatchingURI(f"Not a package.json URI: {uri}")
+
+    if indices is None:
+        indices = list(DEFAULT_PACKAGE_INDICES)
+
+    # Parse version from URI if present
+    version = "latest"
+    package = uri
+    if "@" in uri and not uri.startswith(("http://", "https://")):
+        package, version = uri.rsplit("@", 1)
+
+    # Strip mip: prefix if present (explicit index package)
+    if package.startswith("mip:"):
+        package = package[4:]
+
+    # Resolve package and dependencies
+    resolved = resolve_dependencies(package, version, indices=indices, mpy_version=mpy_version)
+
+    # Download all files
+    for pkg in resolved:
+        for file_info in pkg.files:
+            _download_file(dst, file_info.dest_path, file_info.source_url, file_info.hash)
+
+    return dst
+
+
+def _download_file(
+    dst: Path,
+    dest_path: str,
+    source_url: str,
+    expected_hash: Optional[str] = None,
+    timeout: float = 30.0,
+) -> None:
+    """Download a single file with retry logic and optional hash verification.
+
+    Parameters
+    ----------
+    dst
+        Base destination directory.
+    dest_path
+        Relative path within destination.
+    source_url
+        URL to download from.
+    expected_hash
+        Optional hash to verify (8-char hex from MicroPython index).
+    timeout
+        Request timeout in seconds.
+
+    Raises
+    ------
+    PackageNotFoundError
+        If download fails.
+    IntegrityError
+        If hash verification fails.
+    """
+    file_path = dst / dest_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        response = fetch_url(source_url, timeout=timeout)
+        response.raise_for_status()
+        content = response.content
+    except requests.exceptions.RequestException as e:
+        raise PackageNotFoundError(f"Failed to download {source_url}: {e}") from e
+
+    # Verify hash if provided (case-insensitive comparison)
+    if expected_hash:
+        actual_hash = compute_micropython_hash(content)
+        if actual_hash.lower() != expected_hash.lower():
+            raise IntegrityError(f"Hash mismatch for {dest_path}: expected {expected_hash}, got {actual_hash}")
+
+    file_path.write_bytes(content)

--- a/belay/packagemanager/downloaders/_retry.py
+++ b/belay/packagemanager/downloaders/_retry.py
@@ -1,0 +1,65 @@
+"""Shared retry utilities for downloaders."""
+
+import requests
+from tenacity import (
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+
+def _is_retryable_exception(exc: BaseException) -> bool:
+    """Determine if an exception should trigger a retry.
+
+    Retries on:
+    - Timeout errors
+    - Connection errors
+    - HTTP 429 (rate limit)
+    - HTTP 5xx (server errors)
+
+    Does NOT retry on:
+    - HTTP 4xx (client errors, except 429)
+    """
+    if isinstance(exc, (requests.exceptions.Timeout, requests.exceptions.ConnectionError)):
+        return True
+    if isinstance(exc, requests.exceptions.HTTPError) and exc.response is not None:
+        status = exc.response.status_code
+        return status == 429 or status >= 500
+    return False
+
+
+@retry(
+    retry=retry_if_exception(_is_retryable_exception),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    reraise=True,
+)
+def fetch_url(url: str, timeout: float = 30.0) -> requests.Response:
+    """Fetch URL with retries on transient failures.
+
+    Retries up to 3 times with exponential backoff (1s, 2s, 4s... max 10s)
+    on timeout, connection errors, rate limits (429), and server errors (5xx).
+
+    Parameters
+    ----------
+    url
+        URL to fetch.
+    timeout
+        Request timeout in seconds.
+
+    Returns
+    -------
+    requests.Response
+        Response object (may have non-200 status code for 4xx errors).
+
+    Raises
+    ------
+    requests.exceptions.RequestException
+        If request fails after retries.
+    """
+    response = requests.get(url, timeout=timeout)
+    # Raise for 5xx errors and 429 (rate limit) to trigger retry, but not for other 4xx
+    if response.status_code >= 500 or response.status_code == 429:
+        response.raise_for_status()
+    return response

--- a/belay/packagemanager/downloaders/common.py
+++ b/belay/packagemanager/downloaders/common.py
@@ -1,25 +1,19 @@
+"""Common download utilities."""
+
 import shutil
 from pathlib import Path
 from urllib.parse import urlparse
 
 import fsspec
-from autoregistry import Registry
 
+from belay.packagemanager.downloaders.git import GitProviderUrl, InvalidGitUrlError
 from belay.typing import PathType
-
-# Downloaders should have function signature
-#    def downloader(dst: Path, uri: str) -> Path
-# where the return value is one of:
-#    1. ``dst`` if a folder was downloaded
-#    2. Path to single file if the URI was for a single file.
-downloaders = Registry()
 
 
 class NonMatchingURI(Exception):  # noqa: N818
     """Provided URI does not match downloading function."""
 
 
-# DO NOT decorate with ``@downloaders``, since this must be last.
 def _download_generic(dst: Path, uri: str) -> Path:
     """Downloads a single file or folder to ``dst / <filename>``."""
     parsed = urlparse(uri)
@@ -49,13 +43,61 @@ def _download_generic(dst: Path, uri: str) -> Path:
 
 
 def download_uri(dst_folder: PathType, uri: str) -> Path:
-    """Download ``uri`` by trying all downloaders on ``uri`` until one works."""
+    """Download ``uri`` to destination folder.
+
+    Tries providers in order:
+    1. Git providers (GitHub, GitLab) via GitProviderUrl
+    2. Package.json packages (mip:, github:user/repo without path)
+    3. Generic download (local files, http URLs)
+
+    Parameters
+    ----------
+    dst_folder
+        Destination folder.
+    uri
+        URI to download.
+
+    Returns
+    -------
+    Path
+        Path to downloaded content.
+    """
     dst_folder = Path(dst_folder)
-    for processor in downloaders.values():
-        try:
-            return processor(dst_folder, uri)
-            break
-        except NonMatchingURI:
-            pass
-    else:
-        return _download_generic(dst_folder, uri)
+
+    # Try git providers for single file downloads
+    try:
+        parsed = GitProviderUrl.parse(uri)
+        if parsed.has_file_extension():
+            # Has a file extension - download as single file
+            return parsed.download(dst_folder)
+    except InvalidGitUrlError:
+        pass
+
+    # Try package.json handler (for mip: and package references)
+    from belay.packagemanager.downloaders._package_json import download_package_json
+
+    # Load project config for package index settings (if pyproject.toml exists)
+    try:
+        from belay.project import load_pyproject
+
+        config = load_pyproject()
+        indices = config.package_indices
+        mpy_version = config.mpy_version
+    except FileNotFoundError:
+        # No pyproject.toml found - use defaults (this is expected for standalone use)
+        indices = None
+        mpy_version = None
+    except Exception:
+        # Config parsing errors (TOML syntax, validation, etc.) - use defaults
+        # rather than failing the download. The user will see errors when they
+        # explicitly run config-dependent commands.
+        indices = None
+        mpy_version = None
+
+    try:
+        return download_package_json(dst_folder, uri, indices=indices, mpy_version=mpy_version)
+    except NonMatchingURI:
+        pass
+
+    # Fall back to generic download
+    return _download_generic(dst_folder, uri)

--- a/belay/packagemanager/downloaders/git.py
+++ b/belay/packagemanager/downloaders/git.py
@@ -1,0 +1,311 @@
+"""Base class for git provider URL handling."""
+
+import logging
+import shutil
+from abc import abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+import git
+from autoregistry import Registry
+
+from belay.packagemanager.downloaders._retry import fetch_url
+
+__all__ = [
+    "GitProviderUrl",
+    "InvalidGitUrlError",
+    "rewrite_url",
+]
+
+logger = logging.getLogger(__name__)
+
+
+class InvalidGitUrlError(Exception):
+    """URL is not a recognized git provider URL (GitHub, GitLab, etc.)."""
+
+
+@dataclass
+class GitProviderUrl(Registry, suffix="Url"):
+    """Base class for parsed git provider URLs.
+
+    Subclasses implement provider-specific URL parsing and downloading.
+    Use :meth:`parse` to create instances - it automatically selects the
+    appropriate subclass based on the URL scheme or domain.
+
+    Attributes
+    ----------
+    user
+        The user or organization name.
+    repo
+        The repository name.
+    path
+        The path within the repository (may be empty).
+    branch
+        The branch/tag/ref (from @suffix or default).
+    """
+
+    user: str
+    repo: str
+    path: str
+    branch: str
+
+    # Regex patterns to match full HTTPS URLs - subclasses override
+    https_patterns: tuple = ()
+
+    @property
+    @abstractmethod
+    def scheme(self) -> str:
+        """URL scheme identifier (e.g., 'github', 'gitlab')."""
+
+    @classmethod
+    def parse(cls, url: str, default_branch: str = "HEAD") -> "GitProviderUrl":
+        """Parse a shorthand or full URL into the appropriate provider-specific instance.
+
+        Supports both shorthand syntax (e.g., ``github:user/repo/path@branch``)
+        and full HTTPS URLs (e.g., ``https://github.com/user/repo/blob/main/path``).
+
+        Parameters
+        ----------
+        url
+            URL to parse (shorthand or full HTTPS).
+        default_branch
+            Branch to use if not specified in URL.
+
+        Returns
+        -------
+        GitProviderUrl
+            Parsed URL as provider-specific subclass.
+
+        Raises
+        ------
+        InvalidGitUrlError
+            If the URL is not a recognized git provider URL.
+        ValueError
+            If the URL is recognized but has invalid format.
+
+        Examples
+        --------
+        >>> GitProviderUrl.parse("github:user/repo/file.py@main")
+        GitHubUrl(user='user', repo='repo', path='file.py', branch='main')
+
+        >>> GitProviderUrl.parse("https://github.com/user/repo/blob/main/file.py")
+        GitHubUrl(user='user', repo='repo', path='file.py', branch='main')
+        """
+        parsed = urlparse(url)
+
+        # Try shorthand syntax first (github:, gitlab:, etc.)
+        try:
+            url_class = cls[parsed.scheme]
+            return url_class._parse_shorthand(url, default_branch)
+        except KeyError:
+            pass
+
+        # Try full HTTPS URLs by checking each provider's patterns
+        if parsed.scheme in ("http", "https"):
+            for url_class in cls.values():
+                result = url_class._parse_https(url)
+                if result is not None:
+                    return result
+
+        raise InvalidGitUrlError(f"Not a recognized git provider URL: {url}")
+
+    @classmethod
+    def _parse_shorthand(cls, url: str, default_branch: str) -> "GitProviderUrl":
+        """Parse shorthand URL (e.g., github:user/repo/path@branch)."""
+        parsed = urlparse(url)
+        path = parsed.path
+        branch = default_branch
+
+        # Extract branch if specified with @
+        if "@" in path:
+            path, branch = path.rsplit("@", 1)
+
+        # Parse user/repo/file_path
+        parts = path.split("/", 2)
+        if len(parts) < 2:
+            raise ValueError(f"Invalid {parsed.scheme} URL: {url} (expected {parsed.scheme}:user/repo[/path])")
+
+        user, repo = parts[0], parts[1]
+        file_path = parts[2] if len(parts) > 2 else ""
+
+        return cls(user=user, repo=repo, path=file_path, branch=branch)
+
+    @classmethod
+    def _parse_https(cls, url: str) -> Optional["GitProviderUrl"]:
+        """Parse full HTTPS URL using https_patterns."""
+        for pattern in cls.https_patterns:
+            match = pattern.search(url)
+            if match:
+                user, repo, branch, path = match.groups()
+                return cls(user=user, repo=repo, path=path, branch=branch)
+        return None
+
+    @property
+    def canonical_id(self) -> str:
+        """Return canonical identifier (user/repo) for deduplication."""
+        return f"{self.user}/{self.repo}".lower()
+
+    @property
+    @abstractmethod
+    def raw_url(self) -> str:
+        """Raw content URL for downloading."""
+
+    def has_file_extension(self) -> bool:
+        """Check if path appears to have a file extension.
+
+        Returns True if the last path component contains a dot that is not
+        at the start (to exclude hidden directories like '.github').
+
+        Returns
+        -------
+        bool
+            True if path appears to have a file extension.
+        """
+        if not self.path:
+            return False
+        last_part = self.path.rsplit("/", 1)[-1]
+        dot_pos = last_part.rfind(".")
+        return dot_pos > 0
+
+    @property
+    def repo_url(self) -> str:
+        """Git clone URL for this repository."""
+        return f"https://{self.scheme}.com/{self.user}/{self.repo}.git"
+
+    @property
+    def cache_prefix(self) -> str:
+        """Prefix for cache folder name."""
+        return f"git-{self.scheme}"
+
+    def download(self, dst: Path) -> Path:
+        """Download file or folder to destination.
+
+        Tries to download as a single file first. If that fails (404),
+        falls back to cloning the repository and copying the path.
+
+        Parameters
+        ----------
+        dst
+            Destination directory.
+
+        Returns
+        -------
+        Path
+            Path to downloaded file or folder.
+
+        Raises
+        ------
+        requests.exceptions.RequestException
+            If download fails after retries.
+        git.exc.GitCommandError
+            If git clone/pull/checkout fails.
+        """
+        r = fetch_url(self.raw_url)
+
+        if r.status_code == 200:
+            # Single file download
+            if self.path:
+                dst = dst / Path(self.path).name
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(r.content)
+        elif r.status_code == 404:
+            # Probably a folder - clone repo and copy
+            self._clone_and_copy(dst)
+        else:
+            r.raise_for_status()
+
+        return dst
+
+    def _clone_and_copy(self, dst: Path) -> None:
+        """Clone repository and copy path to destination.
+
+        Parameters
+        ----------
+        dst
+            Destination directory.
+
+        Raises
+        ------
+        git.exc.GitCommandError
+            If git operations fail.
+        """
+        from belay.project import find_cache_folder
+
+        repo_folder = find_cache_folder() / f"{self.cache_prefix}-{self.user}-{self.repo}"
+        repo_folder.mkdir(exist_ok=True, parents=True)
+
+        try:
+            if (repo_folder / ".git").is_dir():
+                repo = git.Repo(repo_folder)
+                try:
+                    repo.remotes.origin.fetch()
+                except git.exc.GitCommandError as e:
+                    # If fetch fails, try to continue with existing state
+                    logger.warning(f"Failed to fetch updates for {self.repo_url}: {e}. Using cached version.")
+            else:
+                repo = git.Repo.clone_from(self.repo_url, repo_folder)
+
+            # Clean and checkout the specific branch/tag
+            repo.git.clean("-xdf")
+            repo.git.checkout(self.branch)
+
+        except git.exc.GitCommandError as e:
+            # Re-raise with more context
+            raise git.exc.GitCommandError(
+                e.command,
+                e.status,
+                stderr=f"Failed to clone/checkout {self.repo_url}@{self.branch}: {e.stderr}",
+            ) from e
+
+        if self.path:
+            shutil.copytree(repo_folder / self.path, dst, dirs_exist_ok=True)
+        else:
+            shutil.copytree(repo_folder, dst, dirs_exist_ok=True)
+
+
+def rewrite_url(url: str, branch: str = "HEAD") -> str:
+    """Rewrite github: or gitlab: shorthand to full URLs.
+
+    For URLs with unrecognized schemes (http://, https://, etc.), returns the
+    original URL unchanged. For recognized git provider schemes (github:, gitlab:),
+    parses and rewrites to full URLs.
+
+    Parameters
+    ----------
+    url
+        URL that may use shorthand syntax.
+    branch
+        Default branch if not specified in URL.
+
+    Returns
+    -------
+    str
+        Full HTTP(S) URL, or the original URL if not a git provider URL.
+
+    Raises
+    ------
+    ValueError
+        If URL uses a recognized git provider scheme (github:, gitlab:) but
+        has invalid format (e.g., missing user/repo).
+
+    Examples
+    --------
+    >>> rewrite_url("github:user/repo/path/file.py")
+    'https://raw.githubusercontent.com/user/repo/HEAD/path/file.py'
+
+    >>> rewrite_url("github:user/repo/path/file.py@main")
+    'https://raw.githubusercontent.com/user/repo/main/path/file.py'
+
+    >>> rewrite_url("gitlab:user/repo/path/file.py@develop")
+    'https://gitlab.com/user/repo/-/raw/develop/path/file.py'
+
+    >>> rewrite_url("https://example.com/file.py")
+    'https://example.com/file.py'
+    """
+    try:
+        parsed = GitProviderUrl.parse(url, default_branch=branch)
+    except InvalidGitUrlError:
+        return url
+    return parsed.raw_url

--- a/belay/packagemanager/models.py
+++ b/belay/packagemanager/models.py
@@ -1,11 +1,77 @@
 """Pydantic models for validation Belay configuration.
 """
 
+import re
 from pathlib import Path
 from typing import Optional
 
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import ConfigDict, field_validator
+
+from belay.packagemanager.package_json import DEFAULT_MPY_VERSION, DEFAULT_PACKAGE_INDICES
+
+# Pattern for version-only strings (e.g., "1.0.0", "2.1", "0.5.1.2")
+_VERSION_PATTERN = re.compile(r"^\d+(\.\d+)*$")
+
+# Characters that indicate version ranges (not supported)
+_VERSION_RANGE_PREFIXES = frozenset("^~><=!")
+
+
+class VersionRangeNotSupportedError(ValueError):
+    """Raised when a version range is specified but not supported."""
+
+
+def _transform_version_uri(package_name: str, uri: str) -> str:
+    """Transform version/wildcard syntax into proper URI for index lookup.
+
+    Parameters
+    ----------
+    package_name
+        The dependency key name (e.g., "aiohttp").
+    uri
+        The dependency value (e.g., "*", "1.0.0", "github:...").
+
+    Returns
+    -------
+    str
+        The URI to use for downloading.
+
+    Raises
+    ------
+    VersionRangeNotSupportedError
+        If a version range syntax is detected.
+
+    Examples
+    --------
+    >>> _transform_version_uri("aiohttp", "*")
+    'aiohttp'
+    >>> _transform_version_uri("aiohttp", "latest")
+    'aiohttp'
+    >>> _transform_version_uri("requests", "1.0.0")
+    'requests@1.0.0'
+    >>> _transform_version_uri("pathlib", "github:user/repo")
+    'github:user/repo'
+    """
+    if not uri:
+        return uri
+
+    # Check for version range syntax (not supported)
+    if uri[0] in _VERSION_RANGE_PREFIXES:
+        raise VersionRangeNotSupportedError(
+            f'Version ranges are not supported: {package_name} = "{uri}". '
+            f'Use "*" for latest or an exact version like "1.0.0".'
+        )
+
+    # Wildcard or "latest" -> use package name for index lookup
+    if uri in ("*", "latest"):
+        return package_name
+
+    # Version string -> package_name@version
+    if _VERSION_PATTERN.match(uri):
+        return f"{package_name}@{uri}"
+
+    # Otherwise, pass through unchanged (URLs, paths, mip:, github:, etc.)
+    return uri
 
 
 class BaseModel(PydanticBaseModel):
@@ -33,6 +99,7 @@ def _dependencies_preprocessor(dependencies) -> dict[str, list[dict]]:
     """Preprocess various dependencies based on dtype.
 
     * ``str`` -> single dependency that may get renamed to __init__.py, if appropriate.
+      Supports version/wildcard syntax: "*", "latest", or "1.0.0".
     * ``list`` -> list of dependencies. If an element is a str, it will not
       get renamed to __init__.py.
     * ``dict`` -> full dependency specification.
@@ -40,9 +107,10 @@ def _dependencies_preprocessor(dependencies) -> dict[str, list[dict]]:
     out = {}
     for group_name, group_value in dependencies.items():
         if isinstance(group_value, str):
+            uri = _transform_version_uri(group_name, group_value)
             group_value = [
                 {
-                    "uri": group_value,
+                    "uri": uri,
                     "rename_to_init": True,
                 }
             ]
@@ -50,6 +118,8 @@ def _dependencies_preprocessor(dependencies) -> dict[str, list[dict]]:
             group_value_out = []
             for elem in group_value:
                 if isinstance(elem, str):
+                    # List elements don't get version transformation
+                    # (they're typically explicit URLs for multi-file packages)
                     group_value_out.append(
                         {
                             "uri": elem,
@@ -64,6 +134,8 @@ def _dependencies_preprocessor(dependencies) -> dict[str, list[dict]]:
             group_value = group_value_out
         elif isinstance(group_value, dict):
             group_value = group_value.copy()
+            if "uri" in group_value:
+                group_value["uri"] = _transform_version_uri(group_name, group_value["uri"])
             group_value.setdefault("rename_to_init", True)
             group_value = [group_value]
         elif isinstance(group_value, DependencySourceConfig):
@@ -137,6 +209,15 @@ class BelayConfig(BaseModel):
     # Other dependencies
     group: dict[str, GroupConfig] = {}
 
+    # MicroPython package index settings
+    # MicroPython version for index package lookups.
+    # Use "py" for pure Python source, or version number like "6" for compiled .mpy files.
+    mpy_version: str = DEFAULT_MPY_VERSION
+
+    # URLs of package indices for MicroPython package name lookups.
+    # Indices are tried in order; first match wins.
+    package_indices: list[str] = list(DEFAULT_PACKAGE_INDICES)
+
     ##############
     # VALIDATORS #
     ##############
@@ -158,4 +239,36 @@ class BelayConfig(BaseModel):
                 'Specify "main" group dependencies under "tool.belay.dependencies", '
                 'not "tool.belay.group.main.dependencies"'
             )
+        return v
+
+    @field_validator("mpy_version")
+    @classmethod
+    def validate_mpy_version(cls, v):
+        """Validate mpy_version is a recognized format.
+
+        Valid values:
+        - "py": Pure Python source files
+        - Numeric string (e.g., "6"): Compiled .mpy format version
+        """
+        if not v:
+            raise ValueError("mpy_version cannot be empty")
+        if v != "py" and not v.isdigit():
+            raise ValueError(
+                f'Invalid mpy_version: "{v}". '
+                'Use "py" for pure Python or a number like "6" for compiled .mpy format.'
+            )
+        return v
+
+    @field_validator("package_indices")
+    @classmethod
+    def validate_package_indices(cls, v):
+        """Validate that package indices are well-formed URLs."""
+        from urllib.parse import urlparse
+
+        for url in v:
+            parsed = urlparse(url)
+            if parsed.scheme not in ("http", "https"):
+                raise ValueError(f"Invalid package index URL (must be http:// or https://): {url}")
+            if not parsed.netloc:
+                raise ValueError(f"Invalid package index URL (missing host): {url}")
         return v

--- a/belay/packagemanager/package_json.py
+++ b/belay/packagemanager/package_json.py
@@ -1,0 +1,224 @@
+"""MicroPython package.json support for Belay.
+
+This module provides support for MicroPython's package.json format,
+including URL rewriting for github:/gitlab: shortcuts and index lookups.
+
+See: https://docs.micropython.org/en/latest/reference/packages.html
+"""
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Optional
+from urllib.parse import urlparse
+
+import requests
+
+from belay.exceptions import PackageNotFoundError
+from belay.packagemanager.downloaders._retry import fetch_url
+from belay.packagemanager.downloaders.git import rewrite_url
+
+__all__ = [
+    "DEFAULT_MPY_VERSION",
+    "DEFAULT_PACKAGE_INDICES",
+    "HASH_LENGTH",
+    "PackageJson",
+    "compute_micropython_hash",
+    "fetch_package_json",
+    "is_index_hash",
+]
+
+DEFAULT_PACKAGE_INDICES = ("https://micropython.org/pi/v2",)
+DEFAULT_MPY_VERSION = "py"
+
+# MicroPython index hashes are 8 hex characters (truncated SHA256)
+HASH_LENGTH = 8
+_HEX_CHARS = frozenset("0123456789abcdefABCDEF")
+
+
+def is_index_hash(source: str) -> bool:
+    """Check if source string looks like a MicroPython index hash.
+
+    MicroPython index hashes are exactly 8 hex characters (case-insensitive).
+
+    Parameters
+    ----------
+    source
+        Source string to check.
+
+    Returns
+    -------
+    bool
+        True if source appears to be an index hash.
+    """
+    return len(source) == HASH_LENGTH and all(c in _HEX_CHARS for c in source)
+
+
+def compute_micropython_hash(content: bytes) -> str:
+    """Compute MicroPython-style file hash (truncated SHA256).
+
+    Parameters
+    ----------
+    content
+        File content to hash.
+
+    Returns
+    -------
+    str
+        8-character lowercase hex hash.
+    """
+    return hashlib.sha256(content).hexdigest()[:HASH_LENGTH]
+
+
+@dataclass
+class PackageJson:
+    """Parsed MicroPython package.json manifest.
+
+    Attributes
+    ----------
+    urls
+        List of (destination_path, source_url) tuples for self-hosted packages.
+    hashes
+        List of (destination_path, hash) tuples for index-based packages.
+    deps
+        List of (package_name, version) dependency tuples.
+    version
+        Package version string.
+    base_url
+        Base URL for resolving relative URLs in this manifest.
+    """
+
+    urls: list[tuple[str, str]] = field(default_factory=list)
+    hashes: list[tuple[str, str]] = field(default_factory=list)
+    deps: list[tuple[str, str]] = field(default_factory=list)
+    version: str = ""
+    base_url: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict, base_url: str = "") -> "PackageJson":
+        """Create PackageJson from parsed JSON dict.
+
+        Parameters
+        ----------
+        data
+            Parsed JSON dictionary.
+        base_url
+            Base URL for resolving relative URLs.
+
+        Returns
+        -------
+        PackageJson
+            Parsed package manifest.
+
+        Raises
+        ------
+        ValueError
+            If the package.json data is malformed.
+        """
+        try:
+            urls = []
+            for item in data.get("urls", []):
+                if not isinstance(item, (list, tuple)) or len(item) != 2:
+                    raise ValueError(f"Invalid urls entry: {item!r} (expected [dest, source])")
+                urls.append((item[0], item[1]))
+
+            hashes = []
+            for item in data.get("hashes", []):
+                if not isinstance(item, (list, tuple)) or len(item) != 2:
+                    raise ValueError(f"Invalid hashes entry: {item!r} (expected [dest, hash])")
+                hashes.append((item[0], item[1]))
+
+            deps = []
+            for item in data.get("deps", []):
+                if not isinstance(item, (list, tuple)) or len(item) != 2:
+                    raise ValueError(f"Invalid deps entry: {item!r} (expected [name, version])")
+                deps.append((item[0], item[1]))
+
+            version = data.get("version", "")
+            if not isinstance(version, str):
+                raise ValueError(f"Invalid version: {version!r} (expected string)")  # noqa: TRY004
+
+            return cls(
+                urls=urls,
+                hashes=hashes,
+                deps=deps,
+                version=version,
+                base_url=base_url,
+            )
+        except (TypeError, KeyError) as e:
+            raise ValueError(f"Malformed package.json data: {e}") from e
+
+
+def _is_url(s: str) -> bool:
+    """Check if string looks like a URL vs package name."""
+    return bool(urlparse(s).scheme)
+
+
+def fetch_package_json(
+    package: str,
+    version: str = "latest",
+    indices: Optional[list[str]] = None,
+    mpy_version: str = DEFAULT_MPY_VERSION,
+    timeout: float = 30.0,
+) -> PackageJson:
+    """Fetch package.json from index or URL.
+
+    Parameters
+    ----------
+    package
+        Package name or URL (github:, gitlab:, http://, https://).
+    version
+        Version string, default "latest".
+    indices
+        Package index URL(s). If None, uses DEFAULT_PACKAGE_INDICES.
+        Indices are tried in order until the package is found.
+    mpy_version
+        MicroPython version for index lookup ("py", "6", etc.).
+    timeout
+        Request timeout in seconds.
+
+    Returns
+    -------
+    PackageJson
+        Parsed package manifest.
+
+    Raises
+    ------
+    PackageNotFoundError
+        If package cannot be found in any index.
+    """
+    if indices is None:
+        indices = list(DEFAULT_PACKAGE_INDICES)
+
+    # Determine if this is a URL or index package name
+    if _is_url(package):
+        url = rewrite_url(package)
+        # Ensure URL points to package.json
+        if not url.endswith(".json"):
+            url = url.rstrip("/") + "/package.json"
+        base_url = url.rsplit("/", 1)[0] + "/"
+
+        try:
+            response = fetch_url(url, timeout=timeout)
+        except requests.exceptions.RequestException as e:
+            raise PackageNotFoundError(f"Failed to fetch package: {package} (URL: {url}): {e}") from e
+
+        if response.status_code == 404:
+            raise PackageNotFoundError(f"Package not found: {package} (URL: {url})")
+
+        data = response.json()
+        return PackageJson.from_dict(data, base_url=base_url)
+
+    # Index lookup - try each index in order
+    for idx in indices:
+        url = f"{idx}/package/{mpy_version}/{package}/{version}.json"
+        try:
+            response = fetch_url(url, timeout=timeout)
+            if response.status_code == 404:
+                continue
+
+            data = response.json()
+            return PackageJson.from_dict(data, base_url=f"{idx}/")
+        except requests.exceptions.RequestException:
+            continue
+
+    raise PackageNotFoundError(f"Package not found in any index: {package}")

--- a/belay/packagemanager/resolver.py
+++ b/belay/packagemanager/resolver.py
@@ -1,0 +1,314 @@
+"""Recursive dependency resolver for MicroPython packages.
+
+This module resolves MicroPython package.json dependencies recursively,
+handling cycle detection and version conflicts.
+
+Example
+-------
+>>> resolved = resolve_dependencies("aiohttp")
+>>> for pkg in resolved:
+...     for f in pkg.files:
+...         download(f.source_url, f.dest_path)
+"""
+
+__all__ = [
+    "CircularDependencyError",
+    "ResolvedFile",
+    "ResolvedPackage",
+    "resolve_dependencies",
+    "resolve_file_url",
+]
+
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+from urllib.parse import urljoin
+
+from belay.packagemanager.downloaders.git import GitProviderUrl, InvalidGitUrlError
+from belay.packagemanager.package_json import (
+    DEFAULT_MPY_VERSION,
+    DEFAULT_PACKAGE_INDICES,
+    PackageJson,
+    fetch_package_json,
+    is_index_hash,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_package_name(package: str) -> str:
+    """Normalize package name for comparison.
+
+    Handles github:/gitlab: URLs by extracting a canonical identifier.
+    All names are lowercased for consistent comparison.
+    """
+    try:
+        parsed = GitProviderUrl.parse(package)
+    except InvalidGitUrlError:
+        return package.lower()
+    return parsed.canonical_id
+
+
+def resolve_file_url(
+    pkg_json: PackageJson,
+    dest_path: str,
+    source: str,
+) -> str:
+    """Resolve a file URL from package.json entry.
+
+    Handles:
+    - Absolute URLs (http://, https://)
+    - Shorthand URLs (github:, gitlab:)
+    - Relative URLs (resolved against base_url)
+    - Hash-based index files (uses base_url to determine index)
+
+    Parameters
+    ----------
+    pkg_json
+        The PackageJson containing this file reference.
+    dest_path
+        Destination path for the file.
+    source
+        Source URL or hash from package.json.
+
+    Returns
+    -------
+    str
+        Full URL to download the file from.
+    """
+    # Check if source is a hash (for index packages)
+    # Uses centralized hash detection logic
+    if is_index_hash(source):
+        # Hash-based lookup - derive index from base_url
+        # base_url is set to "{index}/" when fetched from an index
+        index = pkg_json.base_url.rstrip("/")
+        return f"{index}/file/{source[:2]}/{source}"
+
+    # Rewrite shorthand URLs (github:, gitlab:)
+    try:
+        parsed = GitProviderUrl.parse(source)
+    except InvalidGitUrlError:
+        pass
+    else:
+        return parsed.raw_url
+
+    # Absolute URL
+    if source.startswith(("http://", "https://")):
+        return source
+
+    # Relative URL - resolve against base
+    return urljoin(pkg_json.base_url, source)
+
+
+class CircularDependencyError(Exception):
+    """Circular dependency detected during resolution."""
+
+
+@dataclass
+class ResolvedFile:
+    """A single file to be downloaded and installed.
+
+    Represents one entry from a package.json's ``urls`` or ``hashes`` field.
+    In package.json, files are specified as::
+
+        "urls": [[dest_path, source_url], ...]
+        "hashes": [[dest_path, hash], ...]
+
+    For ``urls``, the source is a URL (absolute, relative, or shorthand like ``github:``).
+    For ``hashes``, the source is an 8-char hex hash used to construct the index URL.
+
+    Attributes
+    ----------
+    dest_path
+        Where to install the file on the device, relative to the installation
+        directory. E.g., ``"mlx90640/__init__.py"``.
+    source_url
+        Full URL to download the file from. This is the resolved form of the
+        source from package.json (relative URLs made absolute, shorthand expanded).
+    hash
+        Optional 8-char hex hash for integrity verification. Present for files
+        from the MicroPython index (``hashes`` field), ``None`` for URL-based
+        packages (``urls`` field).
+    """
+
+    dest_path: str
+    source_url: str
+    hash: Optional[str] = None
+
+
+@dataclass
+class ResolvedPackage:
+    """A fully resolved package with all its files ready for download.
+
+    Created by :func:`resolve_dependencies` after parsing a package.json manifest.
+    Contains the list of :class:`ResolvedFile` entries that need to be downloaded
+    and installed for this package.
+
+    Note that dependencies are resolved separately - each dependency becomes
+    its own :class:`ResolvedPackage` in the output dict.
+
+    Attributes
+    ----------
+    name
+        Package name or URL identifier (e.g., ``"aiohttp"`` or ``"github:user/repo"``).
+    version
+        Resolved version string from package.json, or the requested version
+        if the manifest didn't specify one.
+    files
+        List of :class:`ResolvedFile` to download for this package. Each file
+        specifies both where to download from (:attr:`~ResolvedFile.source_url`)
+        and where to install (:attr:`~ResolvedFile.dest_path`).
+    """
+
+    name: str
+    version: str
+    files: list[ResolvedFile] = field(default_factory=list)
+
+
+def resolve_dependencies(
+    package: str,
+    version: str = "latest",
+    indices: Optional[list[str]] = None,
+    mpy_version: str = DEFAULT_MPY_VERSION,
+) -> list[ResolvedPackage]:
+    """Resolve a package and all its dependencies.
+
+    Given a package name or URL, fetches its package.json manifest, extracts
+    file URLs, and recursively resolves all dependencies. The output is a
+    list of :class:`ResolvedPackage` objects, each containing the files
+    to download.
+
+    Resolution process:
+
+    1. Fetch package.json for the requested package
+    2. Extract file entries from ``urls`` and ``hashes`` fields
+    3. Recursively resolve packages listed in ``deps`` field
+    4. Return all resolved packages as a list
+
+    Handles:
+
+    - Index packages: looked up by name (e.g., ``"aiohttp"``)
+    - URL packages: fetched directly (e.g., ``"github:user/repo"``)
+    - Circular dependency detection (raises :class:`CircularDependencyError`)
+    - Version conflicts (first-wins strategy with warning)
+
+    Parameters
+    ----------
+    package
+        Package name or URL.
+    version
+        Version constraint. Default: ``"latest"``.
+    indices
+        Package index URL(s) for name-based lookups. If None, uses DEFAULT_PACKAGE_INDICES.
+        Indices are tried in order until the package is found.
+    mpy_version
+        MicroPython version for index lookups (``"py"`` for pure Python,
+        ``"6"`` for .mpy format version 6, etc.). Default: ``"py"``.
+
+    Returns
+    -------
+    list[ResolvedPackage]
+        List of resolved packages.
+
+    Raises
+    ------
+    CircularDependencyError
+        If circular dependency detected.
+    PackageNotFoundError
+        If package cannot be found.
+
+    Examples
+    --------
+    >>> resolved = resolve_dependencies("aiohttp")
+    >>> for pkg in resolved:
+    ...     print(f"{pkg.name} v{pkg.version}: {len(pkg.files)} files")
+    ...     for f in pkg.files:
+    ...         print(f"  {f.dest_path} <- {f.source_url}")
+    """
+    if indices is None:
+        indices = list(DEFAULT_PACKAGE_INDICES)
+
+    # Resolution state (captured by closure)
+    resolved: list[ResolvedPackage] = []
+    in_progress: set[str] = set()
+    version_map: dict[str, str] = {}
+
+    def _resolve_recursive(pkg: str, ver: str) -> None:
+        """Internal recursive resolution."""
+        # Normalize package name for dedup and cycle detection
+        # Use package name (not version) for cycle detection to catch A@1.0 -> B -> A@2.0
+        pkg_name_normalized = _normalize_package_name(pkg)
+
+        # Check for version conflicts (same package, different version)
+        if pkg_name_normalized in version_map:
+            existing_version = version_map[pkg_name_normalized]
+            if existing_version != ver:
+                logger.warning(
+                    f"Version conflict for {pkg}: already resolved {existing_version}, "
+                    f"now requested {ver}. Using first-resolved version."
+                )
+            # Already resolved (possibly with different version) - skip
+            return
+
+        # Cycle detection using package name (regardless of version)
+        if pkg_name_normalized in in_progress:
+            raise CircularDependencyError(f"Circular dependency detected: {pkg} (in resolution chain)")
+
+        in_progress.add(pkg_name_normalized)
+
+        try:
+            # Fetch and parse package.json
+            pkg_json = fetch_package_json(
+                pkg,
+                version=ver,
+                indices=indices,
+                mpy_version=mpy_version,
+            )
+
+            # Resolve files
+            files = []
+
+            # Handle urls field (self-hosted packages) - no hash verification
+            for dest, source in pkg_json.urls:
+                url = resolve_file_url(pkg_json, dest, source)
+                files.append(
+                    ResolvedFile(
+                        dest_path=dest,
+                        source_url=url,
+                    )
+                )
+
+            # Handle hashes field (index packages) - with hash verification
+            for dest, hash_val in pkg_json.hashes:
+                url = resolve_file_url(pkg_json, dest, hash_val)
+                files.append(
+                    ResolvedFile(
+                        dest_path=dest,
+                        source_url=url,
+                        hash=hash_val,
+                    )
+                )
+
+            # Recursively resolve dependencies BEFORE marking as resolved
+            # This ensures cycle detection works properly
+            for dep_name, dep_version in pkg_json.deps:
+                _resolve_recursive(dep_name, dep_version)
+
+            # Record the resolved version
+            resolved_version = pkg_json.version or ver
+            version_map[pkg_name_normalized] = resolved_version
+
+            # Store resolved package AFTER all dependencies are resolved
+            resolved.append(
+                ResolvedPackage(
+                    name=pkg,
+                    version=resolved_version,
+                    files=files,
+                )
+            )
+        finally:
+            # Clean up in_progress even if resolution fails
+            in_progress.discard(pkg_name_normalized)
+
+    _resolve_recursive(package, version)
+    return resolved

--- a/poetry.lock
+++ b/poetry.lock
@@ -2221,6 +2221,22 @@ pure-eval = "*"
 tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
+name = "tenacity"
+version = "9.1.2"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138"},
+    {file = "tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx"]
+test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
 name = "tomli"
 version = "2.2.1"
 description = "A lil' TOML parser"
@@ -2490,4 +2506,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "70a380f55e6f8a1decc7d4b0f74e0286990292f184921d2d4a42ea38a2e0b16a"
+content-hash = "04e6111a5eec8f5f2b8813740f054dacad1bf7bc7888d9d4b1f9279eb86115f5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ questionary = ">=2.0.0"
 packaging = ">=20.4"
 attrs = ">=21.0.0"
 tomlkit = ">=0.11.0"
+tenacity = ">=8.0.0"
 
 [tool.poetry.group.docs.dependencies]
 sphinx = ">=6.2.0"

--- a/tests/packagemanager/downloaders/test_common.py
+++ b/tests/packagemanager/downloaders/test_common.py
@@ -1,10 +1,183 @@
-from belay.packagemanager.downloaders.common import _download_generic, downloaders
+import pytest
+
+from belay.packagemanager.downloaders import (
+    GitHubUrl,
+    GitLabUrl,
+    GitProviderUrl,
+    InvalidGitUrlError,
+    rewrite_url,
+)
+from belay.packagemanager.downloaders.common import _download_generic
 
 
-def test_download_registry():
-    assert set(downloaders) == {
-        "github",
-    }
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        # GitHub shorthand
+        (
+            "github:user/repo/path/file.py@main",
+            ("github", "user", "repo", "path/file.py", "main"),
+        ),
+        (
+            "github:user/repo/path/file.py",
+            ("github", "user", "repo", "path/file.py", "HEAD"),
+        ),
+        (
+            "github:user/repo@v1.0",
+            ("github", "user", "repo", "", "v1.0"),
+        ),
+        (
+            "github:user/repo",
+            ("github", "user", "repo", "", "HEAD"),
+        ),
+        # GitLab shorthand
+        (
+            "gitlab:user/repo/path/file.py@develop",
+            ("gitlab", "user", "repo", "path/file.py", "develop"),
+        ),
+        (
+            "gitlab:user/repo",
+            ("gitlab", "user", "repo", "", "HEAD"),
+        ),
+        # GitHub full HTTPS URLs
+        (
+            "https://github.com/user/repo/blob/main/path/file.py",
+            ("github", "user", "repo", "path/file.py", "main"),
+        ),
+        (
+            "https://github.com/user/repo/tree/develop/src",
+            ("github", "user", "repo", "src", "develop"),
+        ),
+        (
+            "https://raw.githubusercontent.com/user/repo/v1.0/lib.py",
+            ("github", "user", "repo", "lib.py", "v1.0"),
+        ),
+        # GitLab full HTTPS URLs
+        (
+            "https://gitlab.com/user/repo/-/blob/main/path/file.py",
+            ("gitlab", "user", "repo", "path/file.py", "main"),
+        ),
+        (
+            "https://gitlab.com/user/repo/-/tree/develop/src",
+            ("gitlab", "user", "repo", "src", "develop"),
+        ),
+        (
+            "https://gitlab.com/user/repo/-/raw/v1.0/lib.py",
+            ("gitlab", "user", "repo", "lib.py", "v1.0"),
+        ),
+    ],
+)
+def test_git_provider_url_parse(url, expected):
+    result = GitProviderUrl.parse(url)
+    assert result is not None
+    assert (result.scheme, result.user, result.repo, result.path, result.branch) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/file.py",
+        "http://bitbucket.org/user/repo",  # Not supported yet
+        "mip:aiohttp",
+        "aiohttp",
+        "",
+    ],
+)
+def test_git_provider_url_parse_raises_for_unrecognized(url):
+    with pytest.raises(InvalidGitUrlError):
+        GitProviderUrl.parse(url)
+
+
+def test_git_provider_url_parse_invalid_format_raises():
+    with pytest.raises(ValueError, match="Invalid github URL"):
+        GitProviderUrl.parse("github:onlyuser")
+
+
+def test_git_provider_url_canonical_id():
+    parsed = GitProviderUrl.parse("github:User/Repo/path@main")
+    assert parsed.canonical_id == "user/repo"
+
+
+def test_git_provider_url_scheme():
+    """Test that scheme property returns correct provider identifier."""
+    github_url = GitProviderUrl.parse("github:user/repo")
+    assert github_url.scheme == "github"
+
+    gitlab_url = GitProviderUrl.parse("gitlab:user/repo")
+    assert gitlab_url.scheme == "gitlab"
+
+    # Also works for HTTPS URLs
+    github_https = GitProviderUrl.parse("https://github.com/user/repo/blob/main/file.py")
+    assert github_https.scheme == "github"
+
+    gitlab_https = GitProviderUrl.parse("https://gitlab.com/user/repo/-/blob/main/file.py")
+    assert gitlab_https.scheme == "gitlab"
+
+
+def test_git_provider_url_raw_url_github():
+    parsed = GitProviderUrl.parse("github:user/repo/path/file.py@main")
+    assert parsed.raw_url == "https://raw.githubusercontent.com/user/repo/main/path/file.py"
+
+    # Without path
+    parsed = GitProviderUrl.parse("github:user/repo@main")
+    assert parsed.raw_url == "https://raw.githubusercontent.com/user/repo/main"
+
+
+def test_git_provider_url_raw_url_gitlab():
+    parsed = GitProviderUrl.parse("gitlab:user/repo/path/file.py@develop")
+    assert parsed.raw_url == "https://gitlab.com/user/repo/-/raw/develop/path/file.py"
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("github:user/repo/file.py", True),
+        ("github:user/repo/path/file.mpy", True),
+        ("github:user/repo/package.json", True),
+        ("github:user/repo/lib", False),  # No extension
+        ("github:user/repo", False),  # No path
+        ("github:user/repo/", False),  # Empty path
+        ("github:user/repo/.github", False),  # Hidden directory (dot at start)
+    ],
+)
+def test_git_provider_url_has_file_extension(url, expected):
+    parsed = GitProviderUrl.parse(url)
+    assert parsed.has_file_extension() == expected
+
+
+def test_rewrite_url_uses_git_provider_url():
+    """Test that rewrite_url correctly delegates to GitProviderUrl.parse."""
+    assert rewrite_url("github:user/repo/file.py@main") == "https://raw.githubusercontent.com/user/repo/main/file.py"
+    assert rewrite_url("gitlab:user/repo/file.py@dev") == "https://gitlab.com/user/repo/-/raw/dev/file.py"
+    # Non-shorthand URLs pass through unchanged
+    assert rewrite_url("https://example.com/file.py") == "https://example.com/file.py"
+
+
+def test_git_provider_url_registry():
+    """Test that subclasses are registered and discoverable."""
+    # Verify registry contains expected providers
+    assert set(GitProviderUrl.keys()) == {"github", "gitlab"}
+
+    # Verify lookup returns correct classes
+    assert GitProviderUrl["github"] is GitHubUrl
+    assert GitProviderUrl["gitlab"] is GitLabUrl
+
+
+def test_git_provider_url_returns_correct_subclass():
+    """Test that parse() returns the correct subclass type."""
+    # Shorthand URLs
+    github_url = GitProviderUrl.parse("github:user/repo")
+    assert isinstance(github_url, GitHubUrl)
+
+    gitlab_url = GitProviderUrl.parse("gitlab:user/repo")
+    assert isinstance(gitlab_url, GitLabUrl)
+
+    # Full HTTPS URLs
+    github_https = GitProviderUrl.parse("https://github.com/user/repo/blob/main/file.py")
+    assert isinstance(github_https, GitHubUrl)
+
+    gitlab_https = GitProviderUrl.parse("https://gitlab.com/user/repo/-/blob/main/file.py")
+    assert isinstance(gitlab_https, GitLabUrl)
 
 
 def test_download_generic_local_single(tmp_path):

--- a/tests/packagemanager/downloaders/test_github.py
+++ b/tests/packagemanager/downloaders/test_github.py
@@ -1,6 +1,6 @@
 import pytest
 
-from belay.packagemanager import downloaders
+from belay.packagemanager.downloaders import GitHubUrl, GitProviderUrl
 
 
 @pytest.mark.network
@@ -10,7 +10,9 @@ def test_download_github_folder(mocker, tmp_path):
     dst_path = tmp_path / "dst"
 
     uri = "https://github.com/BrianPugh/belay/tree/main/tests/github_download_folder"
-    downloaders.github(dst_path, uri)
+    parsed = GitProviderUrl.parse(uri)
+    assert isinstance(parsed, GitHubUrl)
+    parsed.download(dst_path)
 
     assert (dst_path / "__init__.py").exists()
     assert (dst_path / "file1.py").read_text() == 'print("belay test file for downloading.")\n'
@@ -22,6 +24,36 @@ def test_download_github_folder(mocker, tmp_path):
 @pytest.mark.network
 def test_download_github_single(tmp_path):
     uri = "https://github.com/BrianPugh/belay/blob/main/tests/github_download_folder/file1.py"
-    downloaders.github(tmp_path, uri)
+    parsed = GitProviderUrl.parse(uri)
+    assert isinstance(parsed, GitHubUrl)
+    parsed.download(tmp_path)
 
     assert (tmp_path / "file1.py").read_text() == 'print("belay test file for downloading.")\n'
+
+
+@pytest.mark.network
+def test_download_github_shorthand_single(tmp_path):
+    """Test downloading a single file using github: shorthand."""
+    uri = "github:BrianPugh/belay/tests/github_download_folder/file1.py@main"
+    parsed = GitProviderUrl.parse(uri)
+    assert isinstance(parsed, GitHubUrl)
+    parsed.download(tmp_path)
+
+    assert (tmp_path / "file1.py").read_text() == 'print("belay test file for downloading.")\n'
+
+
+@pytest.mark.network
+def test_download_github_shorthand_folder(mocker, tmp_path):
+    """Test downloading a folder using github: shorthand."""
+    mocker.patch("belay.project.find_cache_folder", return_value=tmp_path / ".belay-cache")
+
+    dst_path = tmp_path / "dst"
+
+    uri = "github:BrianPugh/belay/tests/github_download_folder@main"
+    parsed = GitProviderUrl.parse(uri)
+    assert isinstance(parsed, GitHubUrl)
+    parsed.download(dst_path)
+
+    assert (dst_path / "__init__.py").exists()
+    assert (dst_path / "file1.py").read_text() == 'print("belay test file for downloading.")\n'
+    assert (dst_path / "file2.txt").read_text() == "File for testing non-python downloads.\n"

--- a/tests/packagemanager/downloaders/test_gitlab.py
+++ b/tests/packagemanager/downloaders/test_gitlab.py
@@ -1,0 +1,76 @@
+import pytest
+
+from belay.packagemanager.downloaders import GitLabUrl, GitProviderUrl
+
+
+@pytest.mark.network
+def test_download_gitlab_single(tmp_path):
+    """Test downloading a single file from GitLab using full URL."""
+    uri = "https://gitlab.com/pages/plain-html/-/blob/main/public/index.html"
+    parsed = GitProviderUrl.parse(uri)
+    assert isinstance(parsed, GitLabUrl)
+    parsed.download(tmp_path)
+
+    content = (tmp_path / "index.html").read_text()
+    assert "<!DOCTYPE html>" in content
+    assert "Hello World!" in content
+
+
+@pytest.mark.network
+def test_download_gitlab_single_raw(tmp_path):
+    """Test downloading a single file from GitLab using raw URL."""
+    uri = "https://gitlab.com/pages/plain-html/-/raw/main/public/index.html"
+    parsed = GitProviderUrl.parse(uri)
+    assert isinstance(parsed, GitLabUrl)
+    parsed.download(tmp_path)
+
+    content = (tmp_path / "index.html").read_text()
+    assert "<!DOCTYPE html>" in content
+    assert "Hello World!" in content
+
+
+@pytest.mark.network
+def test_download_gitlab_folder(mocker, tmp_path):
+    """Test downloading a folder from GitLab using full URL."""
+    mocker.patch("belay.project.find_cache_folder", return_value=tmp_path / ".belay-cache")
+
+    dst_path = tmp_path / "dst"
+
+    uri = "https://gitlab.com/pages/plain-html/-/tree/main/public"
+    parsed = GitProviderUrl.parse(uri)
+    assert isinstance(parsed, GitLabUrl)
+    parsed.download(dst_path)
+
+    assert (dst_path / "index.html").exists()
+    content = (dst_path / "index.html").read_text()
+    assert "Hello World!" in content
+
+
+@pytest.mark.network
+def test_download_gitlab_shorthand_single(tmp_path):
+    """Test downloading a single file using gitlab: shorthand."""
+    uri = "gitlab:pages/plain-html/public/index.html@main"
+    parsed = GitProviderUrl.parse(uri)
+    assert isinstance(parsed, GitLabUrl)
+    parsed.download(tmp_path)
+
+    content = (tmp_path / "index.html").read_text()
+    assert "<!DOCTYPE html>" in content
+    assert "Hello World!" in content
+
+
+@pytest.mark.network
+def test_download_gitlab_shorthand_folder(mocker, tmp_path):
+    """Test downloading a folder using gitlab: shorthand."""
+    mocker.patch("belay.project.find_cache_folder", return_value=tmp_path / ".belay-cache")
+
+    dst_path = tmp_path / "dst"
+
+    uri = "gitlab:pages/plain-html/public@main"
+    parsed = GitProviderUrl.parse(uri)
+    assert isinstance(parsed, GitLabUrl)
+    parsed.download(dst_path)
+
+    assert (dst_path / "index.html").exists()
+    content = (dst_path / "index.html").read_text()
+    assert "Hello World!" in content

--- a/tests/packagemanager/downloaders/test_package_json.py
+++ b/tests/packagemanager/downloaders/test_package_json.py
@@ -1,0 +1,291 @@
+"""Tests for package.json downloader."""
+
+import pytest
+import requests
+
+from belay.exceptions import IntegrityError, PackageNotFoundError
+from belay.packagemanager.downloaders._package_json import (
+    _is_package_json_uri,
+    _is_plain_package_name,
+    download_package_json,
+)
+from belay.packagemanager.downloaders.common import NonMatchingURI
+from belay.packagemanager.resolver import ResolvedFile, ResolvedPackage
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        # Valid package names
+        ("aiohttp", True),
+        ("ntptime", True),
+        ("micropython-lib", True),
+        ("my_package", True),
+        ("Package123", True),
+        # Invalid - empty
+        ("", False),
+        # Invalid - contains URL scheme indicators
+        ("mip:aiohttp", False),
+        ("github:user/repo", False),
+        ("https://example.com", False),
+        # Invalid - contains path separators
+        ("path/to/file", False),
+        ("path\\to\\file", False),
+        # Invalid - contains file extension
+        ("file.py", False),
+        ("package.json", False),
+        ("lib.mpy", False),
+    ],
+)
+def test_is_plain_package_name(name, expected):
+    assert _is_plain_package_name(name) is expected
+
+
+@pytest.mark.parametrize(
+    "uri,expected",
+    [
+        # Plain package names (index lookup)
+        ("aiohttp", True),
+        ("ntptime", True),
+        ("micropython-lib", True),
+        ("my_package", True),
+        ("aiohttp@1.0.0", True),
+        # mip: prefix (explicit index)
+        ("mip:aiohttp", True),
+        ("mip:ntptime", True),
+        ("mip:aiohttp@1.0.0", True),
+        # github:user/repo (package.json at root)
+        ("github:user/repo", True),
+        ("github:user/repo@main", True),
+        ("github:user/repo/lib", True),
+        ("github:user/repo/package.json", True),
+        # github single files should NOT match
+        ("github:user/repo/file.py", False),
+        ("github:user/repo/file.mpy", False),
+        # gitlab
+        ("gitlab:user/repo", True),
+        ("gitlab:user/repo@main", True),
+        # Explicit .json URLs
+        ("https://example.com/package.json", True),
+        # Regular URLs should NOT match
+        ("https://example.com/file.py", False),
+        # Local paths should NOT match (contain / or .)
+        ("./local/package.json", True),  # ends with .json
+        ("./local/file.py", False),
+    ],
+)
+def test_is_package_json_uri(uri, expected):
+    assert _is_package_json_uri(uri) is expected
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "https://example.com/file.py",
+        "github:user/repo/file.py",
+    ],
+)
+def test_download_package_json_non_matching_raises(tmp_path, uri):
+    """Non-matching URIs should raise NonMatchingURI."""
+    with pytest.raises(NonMatchingURI):
+        download_package_json(tmp_path, uri)
+
+
+@pytest.fixture
+def mock_resolver(mocker):
+    """Fixture that mocks the resolve_dependencies function."""
+    return mocker.patch("belay.packagemanager.downloaders._package_json.resolve_dependencies")
+
+
+@pytest.fixture
+def mock_requests_get(mocker):
+    """Fixture that mocks requests.get in the _retry module."""
+    mock = mocker.patch("belay.packagemanager.downloaders._retry.requests.get")
+    # Set default status_code to 200 for successful responses
+    mock.return_value.status_code = 200
+    return mock
+
+
+def _make_resolved(files):
+    """Helper to create a resolved package list."""
+    return [
+        ResolvedPackage(
+            name="test-pkg",
+            version="1.0",
+            files=[ResolvedFile(dest_path=f[0], source_url=f[1], hash=f[2] if len(f) > 2 else None) for f in files],
+        )
+    ]
+
+
+def test_download_package_json_basic(tmp_path, mock_resolver, mock_requests_get):
+    """Test basic download with mocked resolver."""
+    mock_resolver.return_value = _make_resolved([("test_pkg/__init__.py", "https://example.com/init.py")])
+    mock_requests_get.return_value.content = b"# test content"
+
+    result = download_package_json(tmp_path, "mip:test-pkg")
+
+    assert result == tmp_path
+    assert (tmp_path / "test_pkg" / "__init__.py").read_bytes() == b"# test content"
+
+
+def test_download_package_json_plain_name(tmp_path, mock_resolver, mock_requests_get):
+    """Test download using plain package name (without mip: prefix)."""
+    mock_resolver.return_value = _make_resolved([("aiohttp/__init__.py", "https://example.com/init.py")])
+    mock_requests_get.return_value.content = b"# aiohttp content"
+
+    result = download_package_json(tmp_path, "aiohttp")
+
+    assert result == tmp_path
+    assert (tmp_path / "aiohttp" / "__init__.py").read_bytes() == b"# aiohttp content"
+    # Verify resolve_dependencies was called with the plain name
+    assert mock_resolver.call_args[0] == ("aiohttp", "latest")
+
+
+def test_download_package_json_plain_name_with_version(tmp_path, mock_resolver, mock_requests_get):
+    """Test download using plain package name with version."""
+    mock_resolver.return_value = _make_resolved([("aiohttp/__init__.py", "https://example.com/init.py")])
+    mock_requests_get.return_value.content = b"# aiohttp content"
+
+    result = download_package_json(tmp_path, "aiohttp@1.0.0")
+
+    assert result == tmp_path
+    # Verify resolve_dependencies was called with correct version
+    assert mock_resolver.call_args[0] == ("aiohttp", "1.0.0")
+
+
+def test_download_package_json_with_version(tmp_path, mock_resolver, mock_requests_get):
+    """Test download with version specified."""
+    mock_resolver.return_value = [ResolvedPackage(name="test-pkg", version="1.0.0", files=[])]
+
+    download_package_json(tmp_path, "mip:test-pkg@1.0.0")
+
+    # Verify resolve_dependencies was called with correct package and version
+    assert mock_resolver.call_args[0] == ("test-pkg", "1.0.0")
+
+
+def test_download_package_json_package_not_found(tmp_path, mock_resolver):
+    """Test that PackageNotFoundError bubbles up."""
+    mock_resolver.side_effect = PackageNotFoundError("Not found")
+
+    with pytest.raises(PackageNotFoundError, match="Not found"):
+        download_package_json(tmp_path, "mip:nonexistent-pkg")
+
+
+def test_download_package_json_hash_verification(tmp_path, mock_resolver, mock_requests_get):
+    """Test that hash verification works correctly."""
+    content = b"# verified content"
+    expected_hash = "5d66c65d"  # sha256(content)[:8]
+
+    mock_resolver.return_value = _make_resolved([("test.py", "https://example.com/test.py", expected_hash)])
+    mock_requests_get.return_value.content = content
+
+    download_package_json(tmp_path, "mip:test-pkg")
+    assert (tmp_path / "test.py").read_bytes() == content
+
+
+def test_download_package_json_hash_verification_case_insensitive(tmp_path, mock_resolver, mock_requests_get):
+    """Test that hash verification is case-insensitive."""
+    content = b"# verified content"
+    expected_hash = "5D66C65D"  # sha256(content)[:8] uppercased
+
+    mock_resolver.return_value = _make_resolved([("test.py", "https://example.com/test.py", expected_hash)])
+    mock_requests_get.return_value.content = content
+
+    # Should succeed even though computed hash is lowercase and expected is uppercase
+    download_package_json(tmp_path, "mip:test-pkg")
+    assert (tmp_path / "test.py").read_bytes() == content
+
+
+def test_download_package_json_hash_mismatch(tmp_path, mock_resolver, mock_requests_get):
+    """Test that hash mismatch raises IntegrityError."""
+    mock_resolver.return_value = _make_resolved([("test.py", "https://example.com/test.py", "deadbeef")])
+    mock_requests_get.return_value.content = b"# different content"
+
+    with pytest.raises(IntegrityError, match="Hash mismatch"):
+        download_package_json(tmp_path, "mip:test-pkg")
+
+
+def test_download_package_json_retry_on_timeout(tmp_path, mock_resolver, mock_requests_get, mocker):
+    """Test that download retries on timeout and succeeds."""
+    mocker.patch("tenacity.nap.time.sleep")  # Disable tenacity's sleep for fast tests
+    mock_resolver.return_value = _make_resolved([("test.py", "https://example.com/test.py")])
+
+    success_response = mocker.MagicMock()
+    success_response.status_code = 200
+    success_response.content = b"# success"
+
+    mock_requests_get.side_effect = [
+        requests.exceptions.Timeout("timeout 1"),
+        requests.exceptions.Timeout("timeout 2"),
+        success_response,
+    ]
+
+    result = download_package_json(tmp_path, "mip:test-pkg")
+    assert result == tmp_path
+    assert mock_requests_get.call_count == 3
+
+
+def test_download_package_json_retry_exhausted(tmp_path, mock_resolver, mock_requests_get, mocker):
+    """Test that download fails after retries exhausted."""
+    mocker.patch("tenacity.nap.time.sleep")  # Disable tenacity's sleep for fast tests
+    mock_resolver.return_value = _make_resolved([("test.py", "https://example.com/test.py")])
+    mock_requests_get.side_effect = requests.exceptions.Timeout("always timeout")
+
+    with pytest.raises(PackageNotFoundError, match="Failed to download"):
+        download_package_json(tmp_path, "mip:test-pkg")
+
+
+def test_download_package_json_retry_on_rate_limit(tmp_path, mock_resolver, mock_requests_get, mocker):
+    """Test that download retries on 429 rate limit."""
+    mocker.patch("tenacity.nap.time.sleep")  # Disable tenacity's sleep for fast tests
+    mock_resolver.return_value = _make_resolved([("test.py", "https://example.com/test.py")])
+
+    rate_limit_response = mocker.MagicMock()
+    rate_limit_response.status_code = 429
+    rate_limit_response.raise_for_status.side_effect = requests.exceptions.HTTPError(response=rate_limit_response)
+
+    success_response = mocker.MagicMock()
+    success_response.status_code = 200
+    success_response.content = b"# success"
+    success_response.raise_for_status.return_value = None  # Explicitly set to not raise
+
+    mock_requests_get.side_effect = [rate_limit_response, success_response]
+
+    result = download_package_json(tmp_path, "mip:test-pkg")
+    assert result == tmp_path
+    assert mock_requests_get.call_count == 2
+
+
+def test_download_package_json_no_retry_on_404(tmp_path, mock_resolver, mock_requests_get, mocker):
+    """Test that 404 errors are not retried."""
+    mock_resolver.return_value = _make_resolved([("test.py", "https://example.com/test.py")])
+
+    not_found_response = mocker.MagicMock()
+    not_found_response.status_code = 404
+    not_found_response.raise_for_status.side_effect = requests.exceptions.HTTPError(response=not_found_response)
+    mock_requests_get.return_value = not_found_response
+
+    with pytest.raises(PackageNotFoundError, match="Failed to download"):
+        download_package_json(tmp_path, "mip:test-pkg")
+
+    assert mock_requests_get.call_count == 1
+
+
+@pytest.mark.network
+def test_download_package_json_real_package(tmp_path):
+    """Test downloading a real package from the index using mip: prefix."""
+    result = download_package_json(tmp_path, "mip:ntptime")
+
+    assert result == tmp_path
+    files = list(tmp_path.rglob("*"))
+    assert len([f for f in files if f.is_file()]) > 0
+
+
+@pytest.mark.network
+def test_download_package_json_real_package_plain_name(tmp_path):
+    """Test downloading a real package using plain package name."""
+    result = download_package_json(tmp_path, "ntptime")
+
+    assert result == tmp_path
+    files = list(tmp_path.rglob("*"))
+    assert len([f for f in files if f.is_file()]) > 0

--- a/tests/packagemanager/test_models.py
+++ b/tests/packagemanager/test_models.py
@@ -1,8 +1,11 @@
-import pydantic
 import pytest
 from pydantic import ValidationError
 
-from belay.packagemanager import GroupConfig
+from belay.packagemanager import BelayConfig, GroupConfig
+from belay.packagemanager.models import (
+    VersionRangeNotSupportedError,
+    _transform_version_uri,
+)
 
 
 def test_group_config_multiple_rename_to_init():
@@ -14,3 +17,153 @@ def test_group_config_multiple_rename_to_init():
     }
     with pytest.raises(ValidationError):
         GroupConfig(dependencies=dependencies)
+
+
+def test_belay_config_valid_package_indices():
+    """Test that valid package index URLs are accepted."""
+    config = BelayConfig(package_indices=["https://micropython.org/pi/v2", "http://example.com/index"])
+    assert config.package_indices == ["https://micropython.org/pi/v2", "http://example.com/index"]
+
+
+@pytest.mark.parametrize(
+    "invalid_url,error_fragment",
+    [
+        ("ftp://example.com/index", "must be http:// or https://"),
+        ("file:///local/path", "must be http:// or https://"),
+        ("not-a-url", "must be http:// or https://"),
+        ("https://", "missing host"),
+    ],
+)
+def test_belay_config_invalid_package_indices(invalid_url, error_fragment):
+    """Test that invalid package index URLs raise validation errors."""
+    with pytest.raises(ValidationError) as exc_info:
+        BelayConfig(package_indices=[invalid_url])
+    assert error_fragment in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "mpy_version",
+    [
+        "py",  # Pure Python source
+        "6",  # Compiled .mpy version 6
+        "5",  # Compiled .mpy version 5
+        "123",  # Any numeric string
+    ],
+)
+def test_belay_config_valid_mpy_version(mpy_version):
+    """Test that valid mpy_version values are accepted."""
+    config = BelayConfig(mpy_version=mpy_version)
+    assert config.mpy_version == mpy_version
+
+
+@pytest.mark.parametrize(
+    "invalid_mpy_version,error_fragment",
+    [
+        ("", "cannot be empty"),
+        ("python", 'Use "py" for pure Python'),
+        ("abc", 'Use "py" for pure Python'),
+        ("6.0", 'Use "py" for pure Python'),  # Not purely numeric
+        ("py6", 'Use "py" for pure Python'),  # Not "py" or numeric
+    ],
+)
+def test_belay_config_invalid_mpy_version(invalid_mpy_version, error_fragment):
+    """Test that invalid mpy_version values raise validation errors."""
+    with pytest.raises(ValidationError) as exc_info:
+        BelayConfig(mpy_version=invalid_mpy_version)
+    assert error_fragment in str(exc_info.value)
+
+
+# Tests for version/wildcard URI transformation
+
+
+@pytest.mark.parametrize(
+    "package_name,uri,expected",
+    [
+        # Wildcard -> package name
+        ("aiohttp", "*", "aiohttp"),
+        ("requests", "latest", "requests"),
+        # Version -> package@version
+        ("aiohttp", "1.0.0", "aiohttp@1.0.0"),
+        ("requests", "2.1", "requests@2.1"),
+        ("mylib", "0.5.1.2", "mylib@0.5.1.2"),
+        # Pass-through cases (URLs, paths, explicit mip:, etc.)
+        ("pathlib", "github:user/repo", "github:user/repo"),
+        ("mylib", "gitlab:org/project@main", "gitlab:org/project@main"),
+        ("foo", "https://example.com/foo.py", "https://example.com/foo.py"),
+        ("bar", "../local/path.py", "../local/path.py"),
+        ("baz", "mip:somepackage", "mip:somepackage"),
+        ("qux", "aiohttp", "aiohttp"),  # explicit package name
+        # Empty string passes through
+        ("pkg", "", ""),
+    ],
+)
+def test_transform_version_uri(package_name, uri, expected):
+    """Test _transform_version_uri transforms version syntax correctly."""
+    assert _transform_version_uri(package_name, uri) == expected
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "^1.0.0",
+        "~1.0.0",
+        ">=1.0.0",
+        "<=2.0",
+        ">1.0",
+        "<2.0",
+        "!=1.5.0",
+        "=1.0.0",
+    ],
+)
+def test_transform_version_uri_range_not_supported(uri):
+    """Test that version ranges raise VersionRangeNotSupportedError."""
+    with pytest.raises(VersionRangeNotSupportedError) as exc_info:
+        _transform_version_uri("mypackage", uri)
+    assert "Version ranges are not supported" in str(exc_info.value)
+    assert '"*" for latest' in str(exc_info.value)
+
+
+def test_group_config_wildcard_dependency():
+    """Test GroupConfig parses wildcard dependency syntax."""
+    config = GroupConfig(dependencies={"aiohttp": "*"})
+    assert len(config.dependencies["aiohttp"]) == 1
+    assert config.dependencies["aiohttp"][0].uri == "aiohttp"
+
+
+def test_group_config_version_dependency():
+    """Test GroupConfig parses version dependency syntax."""
+    config = GroupConfig(dependencies={"requests": "1.0.0"})
+    assert config.dependencies["requests"][0].uri == "requests@1.0.0"
+
+
+def test_group_config_latest_dependency():
+    """Test GroupConfig parses 'latest' dependency syntax."""
+    config = GroupConfig(dependencies={"ntptime": "latest"})
+    assert config.dependencies["ntptime"][0].uri == "ntptime"
+
+
+def test_group_config_dict_with_version():
+    """Test GroupConfig parses dict with version URI."""
+    config = GroupConfig(dependencies={"aiohttp": {"uri": "1.0.0"}})
+    assert config.dependencies["aiohttp"][0].uri == "aiohttp@1.0.0"
+
+
+def test_group_config_dict_with_wildcard():
+    """Test GroupConfig parses dict with wildcard URI."""
+    config = GroupConfig(dependencies={"aiohttp": {"uri": "*", "develop": True}})
+    assert config.dependencies["aiohttp"][0].uri == "aiohttp"
+    assert config.dependencies["aiohttp"][0].develop is True
+
+
+def test_group_config_version_range_error():
+    """Test GroupConfig raises error for version ranges."""
+    with pytest.raises(ValidationError) as exc_info:
+        GroupConfig(dependencies={"aiohttp": "^1.0.0"})
+    assert "Version ranges are not supported" in str(exc_info.value)
+
+
+def test_belay_config_wildcard_dependency():
+    """Test BelayConfig parses wildcard dependency syntax."""
+    config = BelayConfig(dependencies={"aiohttp": "*", "requests": "1.0.0"})
+    assert config.dependencies["aiohttp"][0].uri == "aiohttp"
+    assert config.dependencies["requests"][0].uri == "requests@1.0.0"

--- a/tests/packagemanager/test_package_json.py
+++ b/tests/packagemanager/test_package_json.py
@@ -1,0 +1,207 @@
+"""Tests for MicroPython package.json support."""
+
+import pytest
+
+from belay.exceptions import PackageNotFoundError
+from belay.packagemanager.downloaders import rewrite_url
+from belay.packagemanager.package_json import (
+    PackageJson,
+    is_index_hash,
+)
+from belay.packagemanager.resolver import resolve_file_url
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # Valid hashes (case-insensitive)
+        ("abcd1234", True),
+        ("00000000", True),
+        ("ffffffff", True),
+        ("12345678", True),
+        ("ABCD1234", True),  # Uppercase is valid
+        ("AbCd1234", True),  # Mixed case is valid
+        ("FFFFFFFF", True),
+        # Invalid length
+        ("abcd123", False),
+        ("abcd12345", False),
+        ("", False),
+        ("abcd", False),
+        # Invalid chars
+        ("abcdxyz1", False),
+        ("abcd123g", False),
+        ("file.py!", False),
+    ],
+)
+def test_is_index_hash(value, expected):
+    assert is_index_hash(value) is expected
+
+
+@pytest.mark.parametrize(
+    "url,branch,expected",
+    [
+        # GitHub basic
+        ("github:user/repo/path/file.py", "HEAD", "https://raw.githubusercontent.com/user/repo/HEAD/path/file.py"),
+        ("github:user/repo/path/file.py@main", "HEAD", "https://raw.githubusercontent.com/user/repo/main/path/file.py"),
+        (
+            "github:user/repo/path/file.py@v1.2.3",
+            "HEAD",
+            "https://raw.githubusercontent.com/user/repo/v1.2.3/path/file.py",
+        ),
+        ("github:user/repo@main", "HEAD", "https://raw.githubusercontent.com/user/repo/main"),
+        ("github:user/repo", "HEAD", "https://raw.githubusercontent.com/user/repo/HEAD"),
+        ("github:user/repo/file.py", "develop", "https://raw.githubusercontent.com/user/repo/develop/file.py"),
+        # GitLab
+        ("gitlab:user/repo/path/file.py", "HEAD", "https://gitlab.com/user/repo/-/raw/HEAD/path/file.py"),
+        ("gitlab:user/repo/path/file.py@develop", "HEAD", "https://gitlab.com/user/repo/-/raw/develop/path/file.py"),
+        # Passthrough
+        ("https://example.com/file.py", "HEAD", "https://example.com/file.py"),
+        ("http://example.com/file.py", "HEAD", "http://example.com/file.py"),
+    ],
+)
+def test_rewrite_url(url, branch, expected):
+    assert rewrite_url(url, branch=branch) == expected
+
+
+@pytest.mark.parametrize("url", ["github:invalid", "gitlab:onlyuser"])
+def test_rewrite_url_invalid(url):
+    with pytest.raises(ValueError, match="Invalid (github|gitlab) URL"):
+        rewrite_url(url)
+
+
+def test_package_json_from_dict():
+    # Full data
+    data = {
+        "urls": [["dest.py", "source.py"]],
+        "hashes": [["file.mpy", "abcd1234"]],
+        "deps": [["pkg", "1.0"]],
+        "version": "0.1.0",
+    }
+    pkg = PackageJson.from_dict(data, base_url="https://example.com/")
+    assert pkg.urls == [("dest.py", "source.py")]
+    assert pkg.hashes == [("file.mpy", "abcd1234")]
+    assert pkg.deps == [("pkg", "1.0")]
+    assert pkg.version == "0.1.0"
+    assert pkg.base_url == "https://example.com/"
+
+    # Empty data
+    pkg = PackageJson.from_dict({})
+    assert pkg.urls == []
+    assert pkg.deps == []
+    assert pkg.hashes == []
+    assert pkg.version == ""
+
+
+@pytest.mark.parametrize(
+    "data,match",
+    [
+        ({"urls": ["not-a-tuple"]}, "Invalid urls entry"),
+        ({"urls": [["only-one-element"]]}, "Invalid urls entry"),
+        ({"hashes": ["not-a-tuple"]}, "Invalid hashes entry"),
+        ({"deps": ["not-a-tuple"]}, "Invalid deps entry"),
+        ({"version": 123}, "Invalid version"),
+    ],
+)
+def test_package_json_from_dict_invalid(data, match):
+    with pytest.raises(ValueError, match=match):
+        PackageJson.from_dict(data)
+
+
+@pytest.mark.parametrize(
+    "base_url,source,expected",
+    [
+        # Absolute URL
+        ("https://base.com/pkg/", "https://other.com/file.py", "https://other.com/file.py"),
+        # Relative URLs
+        ("https://example.com/repo/", "lib/file.py", "https://example.com/repo/lib/file.py"),
+        ("https://example.com/repo/subdir/", "../file.py", "https://example.com/repo/file.py"),
+        # Shorthand
+        ("", "github:user/repo/file.py@main", "https://raw.githubusercontent.com/user/repo/main/file.py"),
+        ("", "gitlab:user/repo/file.py@develop", "https://gitlab.com/user/repo/-/raw/develop/file.py"),
+        # Hash-based (index packages) - base_url contains the index
+        ("https://micropython.org/pi/v2/", "abcd1234", "https://micropython.org/pi/v2/file/ab/abcd1234"),
+        ("https://micropython.org/pi/v2/", "12345678", "https://micropython.org/pi/v2/file/12/12345678"),
+        # Not a hash (wrong length or chars) - resolved as relative URL
+        ("https://example.com/", "abcd123", "https://example.com/abcd123"),
+        ("https://example.com/", "abcdxyz1", "https://example.com/abcdxyz1"),
+    ],
+)
+def test_resolve_file_url(base_url, source, expected):
+    pkg = PackageJson(base_url=base_url)
+    url = resolve_file_url(pkg, "file.py", source)
+    assert url == expected
+
+
+@pytest.mark.network
+def test_fetch_package_json_from_index():
+    """Test fetching a real package from micropython.org index."""
+    from belay.packagemanager.package_json import fetch_package_json
+
+    pkg = fetch_package_json("ntptime", mpy_version="py")
+    assert pkg.version
+    assert len(pkg.hashes) > 0 or len(pkg.urls) > 0
+
+
+@pytest.mark.network
+def test_fetch_package_json_not_found():
+    """Test that nonexistent packages raise PackageNotFoundError."""
+    from belay.packagemanager.package_json import fetch_package_json
+
+    with pytest.raises(PackageNotFoundError):
+        fetch_package_json("this-package-definitely-does-not-exist-12345")
+
+
+def test_fetch_package_json_multiple_indices_fallback(mocker):
+    """Test that multiple indices are tried in order."""
+    from belay.packagemanager.package_json import fetch_package_json
+
+    mock_get = mocker.patch("belay.packagemanager.package_json.requests.get")
+
+    # First index returns 404, second succeeds
+    first_response = mocker.MagicMock()
+    first_response.status_code = 404
+
+    second_response = mocker.MagicMock()
+    second_response.status_code = 200
+    second_response.json.return_value = {"urls": [["file.py", "https://example.com/file.py"]], "version": "1.0"}
+
+    mock_get.side_effect = [first_response, second_response]
+
+    pkg = fetch_package_json("test-pkg", indices=["https://first.com", "https://second.com"])
+
+    assert pkg.version == "1.0"
+    assert pkg.base_url == "https://second.com/"
+    assert mock_get.call_count == 2
+
+
+def test_fetch_package_json_multiple_indices_first_succeeds(mocker):
+    """Test that first index is used when it succeeds."""
+    from belay.packagemanager.package_json import fetch_package_json
+
+    mock_get = mocker.patch("belay.packagemanager.package_json.requests.get")
+
+    response = mocker.MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"urls": [["file.py", "https://example.com/file.py"]], "version": "1.0"}
+    mock_get.return_value = response
+
+    pkg = fetch_package_json("test-pkg", indices=["https://first.com", "https://second.com"])
+
+    assert pkg.base_url == "https://first.com/"
+    assert mock_get.call_count == 1
+
+
+def test_fetch_package_json_multiple_indices_all_fail(mocker):
+    """Test that PackageNotFoundError is raised when all indices fail."""
+    from belay.packagemanager.package_json import fetch_package_json
+
+    mock_get = mocker.patch("belay.packagemanager.package_json.requests.get")
+
+    response = mocker.MagicMock()
+    response.status_code = 404
+    mock_get.return_value = response
+
+    with pytest.raises(PackageNotFoundError, match="not found in any index"):
+        fetch_package_json("test-pkg", indices=["https://first.com", "https://second.com"])
+
+    assert mock_get.call_count == 2

--- a/tests/packagemanager/test_resolver.py
+++ b/tests/packagemanager/test_resolver.py
@@ -1,0 +1,203 @@
+"""Tests for dependency resolver."""
+
+import logging
+
+import pytest
+
+from belay.packagemanager.package_json import PackageJson
+from belay.packagemanager.resolver import (
+    CircularDependencyError,
+    ResolvedFile,
+    ResolvedPackage,
+    resolve_dependencies,
+)
+
+
+@pytest.fixture
+def mock_fetch(mocker):
+    """Fixture that returns a configurable mock for fetch_package_json."""
+    return mocker.patch("belay.packagemanager.resolver.fetch_package_json")
+
+
+def test_resolve_simple_package(mock_fetch):
+    """Test resolving a package with no dependencies."""
+    mock_fetch.return_value = PackageJson(
+        urls=[("file.py", "https://example.com/file.py")],
+        version="1.0",
+        base_url="https://example.com/",
+    )
+
+    result = resolve_dependencies("test-pkg")
+
+    assert len(result) == 1
+    pkg = result[0]
+    assert pkg.name == "test-pkg"
+    assert pkg.version == "1.0"
+    assert len(pkg.files) == 1
+    assert pkg.files[0].dest_path == "file.py"
+    assert pkg.files[0].hash is None  # URL-based = no hash
+
+
+def test_resolve_with_hashes(mock_fetch):
+    """Test resolving a package with hash-based files (index packages)."""
+    mock_fetch.return_value = PackageJson(
+        hashes=[("pkg/__init__.mpy", "abcd1234"), ("pkg/utils.mpy", "ef985678")],
+        version="1.0",
+        base_url="https://micropython.org/pi/v2/",  # base_url set by fetch_package_json
+    )
+
+    result = resolve_dependencies("test-pkg", indices=["https://micropython.org/pi/v2"])
+
+    assert len(result) == 1
+    pkg = result[0]
+    assert len(pkg.files) == 2
+    assert pkg.files[0].source_url == "https://micropython.org/pi/v2/file/ab/abcd1234"
+    assert pkg.files[0].hash == "abcd1234"
+    assert pkg.files[1].hash == "ef985678"
+
+
+def test_resolve_with_dependencies(mock_fetch):
+    """Test resolving a package with dependencies."""
+
+    def side_effect(package, version, indices, mpy_version):
+        pkgs = {
+            "parent": PackageJson(
+                urls=[("parent.py", "https://example.com/parent.py")],
+                deps=[("child", "1.0")],
+                version="1.0",
+                base_url="https://example.com/",
+            ),
+            "child": PackageJson(
+                urls=[("child.py", "https://example.com/child.py")],
+                version="1.0",
+                base_url="https://example.com/",
+            ),
+        }
+        return pkgs[package]
+
+    mock_fetch.side_effect = side_effect
+
+    result = resolve_dependencies("parent")
+
+    assert len(result) == 2
+    names = {pkg.name for pkg in result}
+    assert names == {"parent", "child"}
+
+
+def test_resolve_diamond_dependency(mock_fetch):
+    """Test diamond dependency pattern (A -> B, C; B -> D; C -> D) with deduplication."""
+    fetch_calls = []
+
+    def side_effect(package, version, indices, mpy_version):
+        fetch_calls.append(package)
+        pkgs = {
+            "A": PackageJson(deps=[("B", "1.0"), ("C", "1.0")], version="1.0"),
+            "B": PackageJson(deps=[("D", "1.0")], version="1.0"),
+            "C": PackageJson(deps=[("D", "1.0")], version="1.0"),
+            "D": PackageJson(
+                urls=[("d.py", "https://example.com/d.py")], version="1.0", base_url="https://example.com/"
+            ),
+        }
+        return pkgs[package]
+
+    mock_fetch.side_effect = side_effect
+
+    result = resolve_dependencies("A")
+
+    assert len(result) == 4
+    assert fetch_calls.count("D") == 1  # D fetched only once
+
+
+@pytest.mark.parametrize(
+    "deps_a,deps_b",
+    [
+        ([("pkg-b", "latest")], [("pkg-a", "latest")]),  # A -> B -> A
+        ([("pkg-b", "1.0")], [("pkg-a", "2.0")]),  # Different versions still detected
+        ([("pkg-a", "latest")], []),  # Self-referential
+    ],
+)
+def test_resolve_circular_dependency(mock_fetch, deps_a, deps_b):
+    """Test that circular dependencies raise an error."""
+    call_count = {"value": 0}
+
+    def side_effect(package, version, indices, mpy_version):
+        call_count["value"] += 1
+        if call_count["value"] > 10:
+            pytest.fail("Too many calls - infinite loop detected")
+        if package == "pkg-a":
+            return PackageJson(deps=deps_a, version="1.0")
+        elif package == "pkg-b":
+            return PackageJson(deps=deps_b, version="1.0")
+        raise ValueError(f"Unknown package: {package}")
+
+    mock_fetch.side_effect = side_effect
+
+    with pytest.raises(CircularDependencyError):
+        resolve_dependencies("pkg-a")
+
+
+def test_resolve_version_conflict_warning(mock_fetch, caplog):
+    """Test that version conflicts generate a warning but use first-wins."""
+
+    def side_effect(package, version, indices, mpy_version):
+        if package == "parent":
+            return PackageJson(deps=[("child", "1.0"), ("child", "2.0")], version="1.0")
+        elif package == "child":
+            return PackageJson(
+                urls=[("child.py", "https://example.com/child.py")],
+                version=version,
+                base_url="https://example.com/",
+            )
+        raise ValueError(f"Unknown package: {package}")
+
+    mock_fetch.side_effect = side_effect
+
+    with caplog.at_level(logging.WARNING):
+        result = resolve_dependencies("parent")
+
+    assert any("Version conflict" in record.message for record in caplog.records)
+    # First-wins: child@1.0 should be resolved, not child@2.0
+    child_pkg = next(pkg for pkg in result if pkg.name == "child")
+    assert child_pkg.version == "1.0"
+
+
+def test_resolve_github_url(mock_fetch):
+    """Test resolving a package from GitHub URL."""
+    mock_fetch.return_value = PackageJson(
+        urls=[("lib.py", "github:user/repo/lib.py@main")],
+        version="0.1",
+    )
+
+    result = resolve_dependencies("github:user/mylib")
+
+    assert len(result) == 1
+    pkg = result[0]
+    assert pkg.files[0].source_url == "https://raw.githubusercontent.com/user/repo/main/lib.py"
+
+
+def test_resolved_file_dataclass():
+    """Test ResolvedFile dataclass attributes."""
+    rf = ResolvedFile(
+        dest_path="pkg/module.py",
+        source_url="https://example.com/module.py",
+        hash="abcd1234",
+    )
+    assert rf.dest_path == "pkg/module.py"
+    assert rf.source_url == "https://example.com/module.py"
+    assert rf.hash == "abcd1234"
+
+    # Default hash is None
+    rf2 = ResolvedFile("a.py", "https://example.com/a.py")
+    assert rf2.hash is None
+
+
+def test_resolved_package_dataclass():
+    """Test ResolvedPackage dataclass attributes."""
+    rp = ResolvedPackage(
+        name="my-pkg",
+        version="1.0.0",
+        files=[ResolvedFile("a.py", "https://example.com/a.py")],
+    )
+    assert rp.name == "my-pkg"
+    assert rp.version == "1.0.0"
+    assert len(rp.files) == 1


### PR DESCRIPTION
# Features

- MicroPython package.json support.
  - Download packages from the MicroPython package index using syntax (`aiohttp = "*"`, `requests = "1.0.0"`) or explicit URIs (`mip:aiohttp`, `aiohttp@1.0.0`)
  - Recursively traverses package dependencies.
- GitLab support.
