### PR TITLE
Wrap convenience import of machine.PWM inside a try/except

### DIFF
--- a/belay/snippets/convenience_imports_micropython.py
+++ b/belay/snippets/convenience_imports_micropython.py
@@ -1,7 +1,11 @@
 import os, machine
 from time import sleep
 from micropython import const
-from machine import Pin, PWM, Timer
+from machine import Pin, Timer
+try:
+    from machine import PWM
+except ImportError:
+    pass
 try:
     from machine import I2C
 except ImportError:

--- a/docs/source/Proxy Objects.rst
+++ b/docs/source/Proxy Objects.rst
@@ -76,16 +76,14 @@ Call methods and use modules naturally:
 .. code-block:: python
 
    # Methods
-   device(
-       """
+   device("""
    class LED:
        def __init__(self, pin):
            self.state = False
        def on(self):
            self.state = True
    led = LED(25)
-   """
-   )
+   """)
    led = device.proxy("led")
    led.on()
    print(led.state)  # True


### PR DESCRIPTION
The stm32 port of micropython doesn't include the `machine.PWM` module, this will make the convenience import optional.

Without this patch, adding the device with:
```python
import belay

device = belay.Device("/dev/ttyACM0")
```
produces the error:
```
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    device = belay.Device("/dev/ttyACM0")
  File "/home/kyoungmeyer/Code/IoT-pyboard/belay/belay/device.py", line 267, in __init__
    self._exec_snippet("convenience_imports_micropython")
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kyoungmeyer/Code/IoT-pyboard/belay/belay/device.py", line 339, in _exec_snippet
    return self("\n".join(snippets), **kwargs)
  File "/home/kyoungmeyer/Code/IoT-pyboard/belay/belay/device.py", line 562, in __call__
    self._board.exec(cmd, data_consumer=data_consumer)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kyoungmeyer/Code/IoT-pyboard/belay/belay/pyboard.py", line 601, in exec
    raise PyboardException(ret_err.decode())
belay.pyboard.PyboardException:

Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
ImportError: can't import name PWM
```
This patch fixes the error. Tested on a Pyboard v1.1 with MicroPython 1.27.0.